### PR TITLE
Dataelement conflict

### DIFF
--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/push/PushConflictTest.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/push/PushConflictTest.java
@@ -112,8 +112,10 @@ public class PushConflictTest {
     @Test
     public void pushWithDataElementConflict(){
         //GIVEN
+        /*
         login(HNQIS_DEV_STAGING, TEST_USERNAME_WITH_PERMISSION, TEST_PASSWORD_WITH_PERMISSION);
-        waitForPull(40);
+        waitForPull(DEFAULT_WAIT_FOR_PULL);
+
         startSurvey(1, 2);
         fillSurvey(7, "Yes");
         Survey survey=Survey.findById(getSurveyId());
@@ -127,7 +129,6 @@ public class PushConflictTest {
         //Simulate the conflict dataelement
 
         //then: Survey is pushed (UID)
-        /*
         Log.d(TAG, "Session user ->" + Session.getUser());
         survey=waitForPush(20,survey.getId_survey());
 

--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/push/PushConflictTest.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/push/PushConflictTest.java
@@ -88,7 +88,7 @@ import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.waitForPush;
 @RunWith(AndroidJUnit4.class)
 public class PushConflictTest {
 
-    private static final String TAG="PushOKTest";
+    private static final String TAG="PushConflictTest";
 
     // private LoginActivity mReceiptCaptureActivity;
 

--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/push/PushConflictTest.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/push/PushConflictTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2016.
+ *
+ * This file is part of QA App.
+ *
+ *  Health Network QIS App is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Health Network QIS App is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eyeseetea.malariacare.test.push;
+
+import android.provider.ContactsContract;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.IdlingResource;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
+
+import com.raizlabs.android.dbflow.sql.builder.Condition;
+import com.raizlabs.android.dbflow.sql.language.Select;
+import com.raizlabs.android.dbflow.sql.language.Update;
+
+import org.eyeseetea.malariacare.LoginActivity;
+import org.eyeseetea.malariacare.R;
+import org.eyeseetea.malariacare.database.model.Answer;
+import org.eyeseetea.malariacare.database.model.Answer$Table;
+import org.eyeseetea.malariacare.database.model.Option;
+import org.eyeseetea.malariacare.database.model.Option$Table;
+import org.eyeseetea.malariacare.database.model.Question;
+import org.eyeseetea.malariacare.database.model.Question$Table;
+import org.eyeseetea.malariacare.database.model.Survey;
+import org.eyeseetea.malariacare.database.model.Value;
+import org.eyeseetea.malariacare.database.model.Value$Table;
+import org.eyeseetea.malariacare.database.utils.PreferencesState;
+import org.eyeseetea.malariacare.database.utils.Session;
+import org.eyeseetea.malariacare.test.utils.ElapsedTimeIdlingResource;
+import org.eyeseetea.malariacare.test.utils.SDKTestUtils;
+import org.eyeseetea.malariacare.utils.Constants;
+import org.hamcrest.Matchers;
+import org.hisp.dhis.android.sdk.persistence.models.DataElement;
+import org.hisp.dhis.android.sdk.persistence.models.DataElement$Table;
+import org.hisp.dhis.android.sdk.persistence.models.DataValue;
+import org.hisp.dhis.android.sdk.persistence.models.DataValue$Table;
+import org.hisp.dhis.android.sdk.persistence.models.OptionSet;
+import org.hisp.dhis.android.sdk.persistence.models.OptionSet$Table;
+import org.hisp.dhis.android.sdk.utils.api.ValueType;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withTagValue;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static junit.framework.Assert.assertTrue;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.DEFAULT_WAIT_FOR_PULL;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.HNQIS_DEV_STAGING;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.TEST_PASSWORD_WITH_PERMISSION;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.TEST_USERNAME_WITH_PERMISSION;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.fillSurvey;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.getActivityInstance;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.getSurveyId;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.login;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.markInProgressAsCompleted;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.startSurvey;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.waitForPull;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.waitForPush;
+
+/**
+ * Created by idelcano on 24/02/16.
+ */
+@RunWith(AndroidJUnit4.class)
+public class PushConflictTest {
+
+    private static final String TAG="PushOKTest";
+
+    // private LoginActivity mReceiptCaptureActivity;
+
+    @Rule
+    public ActivityTestRule<LoginActivity> mActivityRule = new ActivityTestRule<>(
+            LoginActivity.class);
+
+    @Before
+    public void setup(){
+        //force init go to logging activity.
+        SDKTestUtils.goToLogin();
+        //set the test limit( and throw exception if the time is exceded)
+        SDKTestUtils.setTestTimeoutSeconds(SDKTestUtils.DEFAULT_TEST_TIME_LIMIT);
+    }
+
+    @AfterClass
+    public static void exitApp() throws Exception {
+        SDKTestUtils.exitApp();
+    }
+
+    @Test
+    public void pushWithDataElementConflict(){
+        //GIVEN
+        login(HNQIS_DEV_STAGING, TEST_USERNAME_WITH_PERMISSION, TEST_PASSWORD_WITH_PERMISSION);
+        waitForPull(40);
+        startSurvey(1, 2);
+        fillSurvey(7, "Yes");
+        Survey survey=Survey.findById(getSurveyId());
+
+        Long idSurvey=markInProgressAsCompleted();
+
+
+
+
+        //WHEN
+        //Simulate the conflict dataelement
+
+        //then: Survey is pushed (UID)
+        /*
+        Log.d(TAG, "Session user ->" + Session.getUser());
+        survey=waitForPush(20,survey.getId_survey());
+
+
+        onView(withText(android.R.string.ok)).perform(click());
+        checkConflict();
+        //then: Row is gone
+        onView(withId(R.id.score)).check(doesNotExist());
+        survey=Survey.findById(survey.getId_survey());
+        Log.d(TAG,survey.toString());
+        assertTrue(survey.getEventUid() == null);
+
+        assertTrue(survey.getStatus() == Constants.SURVEY_CONFLICT);
+        */
+    }
+
+
+    public static void checkConflict() {
+        //when: click on assess tab + plus button
+        onView(withTagValue(Matchers.is((Object) PreferencesState.getInstance().getContext().getString(R.string.tab_tag_improve)))).perform(click());
+
+
+        IdlingResource idlingResource = new ElapsedTimeIdlingResource(5 * 1000);
+        Espresso.registerIdlingResources(idlingResource);
+        String text=getActivityInstance().getApplicationContext().getString(R.string.feedback_info_conflict);
+        text=text.toUpperCase();
+        onView(withText(text)).perform(click());
+
+        Espresso.unregisterIdlingResources(idlingResource);
+
+        //Wait for SurveyService loads feedback
+        idlingResource = new ElapsedTimeIdlingResource(5 * 1000);
+        Espresso.registerIdlingResources(idlingResource);
+        try {
+            onView(withId(R.string.feedback_info_conflict)).perform(click());
+        }catch (Exception e){
+            //It can fail if the mobile resolution fill the text
+        }
+
+        Espresso.unregisterIdlingResources(idlingResource);
+
+    }
+}

--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/push/PushErrorTest.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/push/PushErrorTest.java
@@ -49,6 +49,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static junit.framework.Assert.assertTrue;
 import static org.eyeseetea.malariacare.database.model.Program.getAllPrograms;
 import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.DEFAULT_WAIT_FOR_PULL;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.HNQIS_DEV_CI;
 import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.login;
 import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.waitForPull;
 import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.DEFAULT_WAIT_FOR_PULL;
@@ -91,7 +92,7 @@ public class PushErrorTest {
     @Test
     public void pushWithOutPermissionsDoesNOTPush(){
         //GIVEN
-        login(HNQIS_DEV_STAGING, TEST_USERNAME_WITH_PERMISSION, TEST_PASSWORD_WITH_PERMISSION);
+        login(HNQIS_DEV_CI, TEST_USERNAME_WITH_PERMISSION, TEST_PASSWORD_WITH_PERMISSION);
         waitForPull(DEFAULT_WAIT_FOR_PULL);
         startSurvey(1, 1);
         fillSurvey(7, "No");

--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/push/PushErrorTest.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/push/PushErrorTest.java
@@ -19,11 +19,17 @@
 
 package org.eyeseetea.malariacare.test.push;
 
+import android.nfc.Tag;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
 
 import org.eyeseetea.malariacare.LoginActivity;
+import org.eyeseetea.malariacare.R;
+import org.eyeseetea.malariacare.database.model.OrgUnit;
+import org.eyeseetea.malariacare.database.model.Program;
+import org.eyeseetea.malariacare.database.model.Survey;
+import org.eyeseetea.malariacare.database.model.TabGroup;
 import org.eyeseetea.malariacare.database.utils.PopulateDB;
 import org.eyeseetea.malariacare.test.utils.SDKTestUtils;
 import org.junit.AfterClass;
@@ -33,12 +39,28 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.List;
+
+import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static junit.framework.Assert.assertTrue;
+import static org.eyeseetea.malariacare.database.model.Program.getAllPrograms;
 import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.DEFAULT_WAIT_FOR_PULL;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.login;
 import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.waitForPull;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.DEFAULT_WAIT_FOR_PULL;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.HNQIS_DEV_STAGING;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.TEST_PASSWORD_WITH_PERMISSION;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.TEST_USERNAME_WITH_PERMISSION;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.fillSurvey;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.getSurveyId;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.markInProgressAsCompleted;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.startSurvey;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.waitForPull;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.waitForPush;
 
 /**
  * Created by arrizabalaga on 3/02/16.
@@ -68,20 +90,40 @@ public class PushErrorTest {
 
     @Test
     public void pushWithOutPermissionsDoesNOTPush(){
-    /*
-        login(HNQIS_DEV_STAGING, TEST_USERNAME_NO_PERMISSION, TEST_PASSWORD_NO_PERMISSION);
+        //GIVEN
+        login(HNQIS_DEV_STAGING, TEST_USERNAME_WITH_PERMISSION, TEST_PASSWORD_WITH_PERMISSION);
         waitForPull(DEFAULT_WAIT_FOR_PULL);
         startSurvey(1, 1);
         fillSurvey(7, "No");
+        createFalseOrgUnitAndProgram();
+
+        //WHEN
+
         Long idSurvey=markInProgressAsCompleted();
 
-        //then: Survey is NOT pushed (no UID)
         Survey survey=waitForPush(20,idSurvey);
+
+        //THEN
+        //then: Survey is NOT pushed (no UID)
         assertTrue(survey.getEventUid() == null);
 
         //then: Row is gone
         onView(withId(R.id.score)).check(doesNotExist());
-    */
+    }
+
+    private void createFalseOrgUnitAndProgram() {
+        //Create the Test Program and OrgUnit to compare with real data.
+        //Fixme the orgunitlevel is not pulled.
+        List<Program> programs= Program.getAllPrograms();
+        Program program= programs.get(0);
+        program.setUid("d6PHrjjljS1");
+        program.setName("KE - HNQIS SF false test");
+
+        List<OrgUnit> orgunits= OrgUnit.getAllOrgUnit();
+        OrgUnit orgUnit= orgunits.get(0);
+        orgUnit.addProgram(program);
+        program.save();
+        orgUnit.save();
     }
 
 }

--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/utils/SDKTestUtils.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/utils/SDKTestUtils.java
@@ -37,6 +37,7 @@ import org.eyeseetea.malariacare.DashboardActivity;
 import org.eyeseetea.malariacare.LoginActivity;
 import org.eyeseetea.malariacare.ProgressActivity;
 import org.eyeseetea.malariacare.R;
+import org.eyeseetea.malariacare.SettingsActivity;
 import org.eyeseetea.malariacare.database.model.OrgUnit;
 import org.eyeseetea.malariacare.database.model.OrgUnit$Table;
 import org.eyeseetea.malariacare.database.model.Program;
@@ -188,7 +189,7 @@ public class SDKTestUtils {
         return idSurvey;
     }
 
-    private static Long getSurveyId(){
+    public static Long getSurveyId(){
         return getSurveyInProgress().getId_survey();
     }
 
@@ -296,7 +297,15 @@ public class SDKTestUtils {
                             onView(withText(android.R.string.ok)).perform(click());
                         } catch (Exception e) {}
                     }
+                else if(SettingsActivity.class.equals(actualClass)){
+                    Espresso.pressBack();
+                }
             } catch (Exception e) {}
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
             goToLogin();
         }
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -30,6 +30,8 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.text.Html;
@@ -83,11 +85,15 @@ public class DashboardActivity extends BaseActivity implements DashboardUnsentFr
     String currentTab;
     String currentTabName;
     boolean isMoveToLeft;
+    static Handler handler;
+    static Activity dashboardActivity;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         Log.d(TAG, "onCreate");
         super.onCreate(savedInstanceState);
+        handler = new Handler(Looper.getMainLooper());
+        dashboardActivity=this;
         setContentView(R.layout.tab_dashboard);
         try {
             initDataIfRequired();
@@ -548,7 +554,7 @@ public class DashboardActivity extends BaseActivity implements DashboardUnsentFr
                 .setTitle(R.string.survey_title_exit)
                 .setMessage(R.string.survey_info_exit).setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int arg1) {
-                Survey survey=Session.getSurvey();
+                Survey survey = Session.getSurvey();
                 survey.updateSurveyStatus();
                 closeSurveyFragment();
             }
@@ -731,5 +737,33 @@ public class DashboardActivity extends BaseActivity implements DashboardUnsentFr
      */
     public void setAlarm() {
         AlarmPushReceiver.getInstance().setPushAlarm(this);
+    }
+
+
+
+    //Show dialog exception from class without activity.
+    public static void showException(final String title, final String errorMessage) {
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                // Run your task here
+                new Handler(Looper.getMainLooper()).post(new Runnable() {
+                    @Override
+                    public void run() {
+                        String dialogTitle = "", dialogMessage = "";
+                        if (title != null)
+                            dialogTitle = title;
+                        if (errorMessage != null)
+                            dialogMessage = errorMessage;
+                        new AlertDialog.Builder(dashboardActivity)
+                                .setCancelable(false)
+                                .setTitle(dialogTitle)
+                                .setMessage(dialogMessage)
+                                .setNeutralButton(android.R.string.ok, null)
+                                .create().show();
+                    }
+                });
+            }
+        }, 1000);
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/ProgressActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/ProgressActivity.java
@@ -479,7 +479,6 @@ public class ProgressActivity extends Activity {
                 new Handler(Looper.getMainLooper()).post(new Runnable() {
                     @Override
                     public void run() {
-                        Log.d("entra", errorMessage);
                         String dialogTitle="",dialogMessage="";
                         if(title!=null)
                             dialogTitle=title;

--- a/app/src/main/java/org/eyeseetea/malariacare/database/AppDatabase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/AppDatabase.java
@@ -27,6 +27,6 @@ import com.raizlabs.android.dbflow.annotation.Database;
 @Database(name = AppDatabase.NAME, version = AppDatabase.VERSION, foreignKeysSupported = true, holderClassSuffix = AppDatabase.HOLDERCLASSSUFFIX)
 public class AppDatabase {
     public static final String NAME = "EyeSeeTeaDB";
-    public static final int VERSION = 7;
+    public static final int VERSION = 6;
     public static final String HOLDERCLASSSUFFIX = "_EyeSeeTeaDB";
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/database/AppDatabase.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/AppDatabase.java
@@ -27,6 +27,6 @@ import com.raizlabs.android.dbflow.annotation.Database;
 @Database(name = AppDatabase.NAME, version = AppDatabase.VERSION, foreignKeysSupported = true, holderClassSuffix = AppDatabase.HOLDERCLASSSUFFIX)
 public class AppDatabase {
     public static final String NAME = "EyeSeeTeaDB";
-    public static final int VERSION = 5;
+    public static final int VERSION = 7;
     public static final String HOLDERCLASSSUFFIX = "_EyeSeeTeaDB";
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -19,6 +19,7 @@
 
 package org.eyeseetea.malariacare.database.iomodules.dhis.exporter;
 
+import android.app.AlertDialog;
 import android.content.Context;
 import android.location.Location;
 import android.util.Log;
@@ -27,6 +28,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.language.Select;
 
+import org.eyeseetea.malariacare.DashboardActivity;
+import org.eyeseetea.malariacare.ProgressActivity;
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.EventExtended;
 import org.eyeseetea.malariacare.database.model.CompositeScore;
@@ -292,8 +295,6 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
             if(hasImportSummaryErrors(importSummary) || failedItem!=null){
                 //Some error happened -> move back to completed
                 if(failedItem!=null) {
-                    //fixme
-                    //show alert dialog
                     ImportSummary importSummary1=failedItem.getImportSummary();
                     List<String> failedUids=getFailedUidQuestion(failedItem.getErrorMessage());
                     for(String uid:failedUids) {
@@ -340,18 +341,18 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
      * @return
      */
     private List<String> getFailedUidQuestion(String responseData){
+        String message="";
         List<String> uid=new ArrayList<>();
         JSONArray jsonArrayResponse=null;
         JSONObject jsonObjectResponse= null;
         try {
             jsonObjectResponse = new JSONObject(responseData);
-            //String status=jsonResponse.getString("status");
+            //String status=jsonObjectResponse.getString("status");
 
-            //String httpStatusCode=jsonResponse.getString("httpStatusCode");
+            //String httpStatusCode=jsonObjectResponse.getString("httpStatusCode");
 
-            //String httpStatus=jsonResponse.getString("httpStatus");
-
-            //String message=jsonResponse.getString("message");
+            //String httpStatus=jsonObjectResponse.getString("httpStatus");
+            message=jsonObjectResponse.getString("message");
             jsonObjectResponse=new JSONObject(jsonObjectResponse.getString("response"));
             jsonArrayResponse=new JSONArray(jsonObjectResponse.getString("importSummaries"));
             try {
@@ -369,6 +370,8 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
         } catch (JSONException e) {
             e.printStackTrace();
         }
+        if(message!="")
+            DashboardActivity.showException(context.getString(R.string.error_message), message);
         return  uid;
     }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -23,6 +23,10 @@ import android.content.Context;
 import android.location.Location;
 import android.util.Log;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.raizlabs.android.dbflow.sql.builder.Condition;
+import com.raizlabs.android.dbflow.sql.language.Select;
+
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.EventExtended;
 import org.eyeseetea.malariacare.database.model.CompositeScore;
@@ -38,7 +42,12 @@ import org.eyeseetea.malariacare.utils.Constants;
 import org.eyeseetea.malariacare.utils.Utils;
 import org.hisp.dhis.android.sdk.persistence.models.DataValue;
 import org.hisp.dhis.android.sdk.persistence.models.Event;
+import org.hisp.dhis.android.sdk.persistence.models.FailedItem;
+import org.hisp.dhis.android.sdk.persistence.models.FailedItem$Table;
 import org.hisp.dhis.android.sdk.persistence.models.ImportSummary;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -115,18 +124,18 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
         updateSurvey(compositeScores);
 
         //Turn score values into dataValues
-        Log.d(TAG,"Creating datavalues from scores...");
+        Log.d(TAG, "Creating datavalues from scores...");
         for(CompositeScore compositeScore:compositeScores){
             compositeScore.accept(this);
         }
 
         //Turn question values into dataValues
-        Log.d(TAG,"Creating datavalues from questions...");
+        Log.d(TAG, "Creating datavalues from questions...");
         for(Value value:survey.getValues()){
             value.accept(this);
         }
 
-        Log.d(TAG,"Creating datavalues from other stuff...");
+        Log.d(TAG, "Creating datavalues from other stuff...");
         buildControlDataElements(survey);
 
         //Annotate both objects to update its state once the process is over
@@ -279,10 +288,24 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
             Survey iSurvey=surveys.get(i);
             Event iEvent=events.get(i);
             ImportSummary importSummary=importSummaryMap.get(iEvent.getLocalId());
-            if(hasImportSummaryErrors(importSummary)){
+            FailedItem failedItem= hasConflict(iEvent.getLocalId());
+            if(hasImportSummaryErrors(importSummary) || failedItem!=null){
                 //Some error happened -> move back to completed
-                iSurvey.setStatus(Constants.SURVEY_COMPLETED);
-                iSurvey.setEventUid(null);
+                if(failedItem!=null) {
+                    //fixme
+                    //show alert dialog
+                    ImportSummary importSummary1=failedItem.getImportSummary();
+                    List<String> failedUids=getFailedUidQuestion(failedItem.getErrorMessage());
+                    for(String uid:failedUids) {
+                        iSurvey.saveConflict(uid);
+                    }
+                    iSurvey.setStatus(Constants.SURVEY_CONFLICT);
+                    iSurvey.setEventUid(null);
+                }
+                else{
+                    iSurvey.setStatus(Constants.SURVEY_COMPLETED);
+                    iSurvey.setEventUid(null);
+                }
                 iSurvey.save();
 
                 //Generated event must be remove too
@@ -296,6 +319,57 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
                 iEvent.save();
             }
         }
+    }
+
+    /**
+     * Checks whether the given event contains errors in SDK FailedItem table or has been successful.
+     * If not return null, it is becouse this item had a conflict.
+     * @param localId
+     * @return
+     */
+    private FailedItem hasConflict(long localId){
+        return  new Select()
+                        .from(FailedItem.class)
+                        .where(Condition.column(FailedItem$Table.ITEMID)
+                                .is(localId)).querySingle();
+    }
+
+    /**
+     * Get dataelement fails from errormessage JSON.
+     * @param responseData
+     * @return
+     */
+    private List<String> getFailedUidQuestion(String responseData){
+        List<String> uid=new ArrayList<>();
+        JSONArray jsonArrayResponse=null;
+        JSONObject jsonObjectResponse= null;
+        try {
+            jsonObjectResponse = new JSONObject(responseData);
+            //String status=jsonResponse.getString("status");
+
+            //String httpStatusCode=jsonResponse.getString("httpStatusCode");
+
+            //String httpStatus=jsonResponse.getString("httpStatus");
+
+            //String message=jsonResponse.getString("message");
+            jsonObjectResponse=new JSONObject(jsonObjectResponse.getString("response"));
+            jsonArrayResponse=new JSONArray(jsonObjectResponse.getString("importSummaries"));
+            try {
+                jsonObjectResponse=new JSONObject(jsonArrayResponse.getString(0));
+                //conflicts
+                jsonArrayResponse=new JSONArray(jsonObjectResponse.getString("conflicts"));
+                //values
+                for(int i=0;i<jsonArrayResponse.length();i++) {
+                    jsonObjectResponse = new JSONObject(jsonArrayResponse.getString(i));
+                    uid.add(jsonObjectResponse.getString("object"));
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return  uid;
     }
 
     /**

--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -355,17 +355,13 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
             message=jsonObjectResponse.getString("message");
             jsonObjectResponse=new JSONObject(jsonObjectResponse.getString("response"));
             jsonArrayResponse=new JSONArray(jsonObjectResponse.getString("importSummaries"));
-            try {
-                jsonObjectResponse=new JSONObject(jsonArrayResponse.getString(0));
-                //conflicts
-                jsonArrayResponse=new JSONArray(jsonObjectResponse.getString("conflicts"));
-                //values
-                for(int i=0;i<jsonArrayResponse.length();i++) {
-                    jsonObjectResponse = new JSONObject(jsonArrayResponse.getString(i));
-                    uid.add(jsonObjectResponse.getString("object"));
-                }
-            } catch (JSONException e) {
-                e.printStackTrace();
+            jsonObjectResponse=new JSONObject(jsonArrayResponse.getString(0));
+            //conflicts
+            jsonArrayResponse=new JSONArray(jsonObjectResponse.getString("conflicts"));
+            //values
+            for(int i=0;i<jsonArrayResponse.length();i++) {
+                jsonObjectResponse = new JSONObject(jsonArrayResponse.getString(i));
+                uid.add(jsonObjectResponse.getString("object"));
             }
         } catch (JSONException e) {
             e.printStackTrace();

--- a/app/src/main/java/org/eyeseetea/malariacare/database/migrations/MigrationAddConflictValue.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/migrations/MigrationAddConflictValue.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016.
+ *
+ * This file is part of QA App.
+ *
+ *  Health Network QIS App is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Health Network QIS App is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eyeseetea.malariacare.database.migrations;
+
+import android.database.sqlite.SQLiteDatabase;
+
+import com.raizlabs.android.dbflow.annotation.Migration;
+import com.raizlabs.android.dbflow.sql.migration.BaseMigration;
+
+import org.eyeseetea.malariacare.database.AppDatabase;
+import org.eyeseetea.malariacare.database.model.Value;
+
+import static org.eyeseetea.malariacare.database.migrations.MigrationUtils.addColumn;
+
+/**
+ * Created by idelcano on 23/02/2016.
+ */
+@Migration(version = 6, databaseName = AppDatabase.NAME)
+public class MigrationAddConflictValue extends BaseMigration {
+
+    public MigrationAddConflictValue() {
+        super();
+    }
+
+    public void onPreMigrate() {
+    }
+
+    @Override
+    public void migrate(SQLiteDatabase database) {
+        addColumn(database, Value.class, "conflict", "boolean");
+    }
+
+    @Override
+    public void onPostMigrate() {
+    }
+
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/database/model/Survey.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/model/Survey.java
@@ -642,17 +642,35 @@ public class Survey extends BaseModel implements VisitableToSDK {
                 .orderBy(Survey$Table.ID_ORG_UNIT).queryList();
     }
     /**
-     * Returns all the surveys with status put to "Sent" or completed
+     * Returns all the surveys with status put to "Sent" or completed or Conflict
      * @return
      */
     public static List<Survey> getAllSentOrCompletedSurveys() {
         return new Select().from(Survey.class)
                 .where(Condition.column(Survey$Table.STATUS).eq(Constants.SURVEY_SENT))
                 .or(Condition.column(Survey$Table.STATUS).eq(Constants.SURVEY_COMPLETED))
+                .or(Condition.column(Survey$Table.STATUS).eq(Constants.SURVEY_CONFLICT))
                 .orderBy(Survey$Table.EVENTDATE)
                 .orderBy(Survey$Table.ID_ORG_UNIT).queryList();
     }
 
+    public void saveConflict(String uid){
+        for(Value value:getValues()){
+            if(value.getQuestion().getUid().equals(uid)){
+                value.setConflict(true);
+                value.save();
+            }
+        }
+    }
+
+    public boolean hasConflict(){
+        for(Value value:getValues()){
+            if(value.getConflict()){
+                return true;
+            }
+        }
+        return false;
+    }
 
     public void prepareSurveyCompletionDate() {
         if (!isSent()) {

--- a/app/src/main/java/org/eyeseetea/malariacare/database/model/Survey.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/model/Survey.java
@@ -645,7 +645,7 @@ public class Survey extends BaseModel implements VisitableToSDK {
      * Returns all the surveys with status put to "Sent" or completed or Conflict
      * @return
      */
-    public static List<Survey> getAllSentOrCompletedSurveys() {
+    public static List<Survey> getAllSentCompletedOrConflictSurveys() {
         return new Select().from(Survey.class)
                 .where(Condition.column(Survey$Table.STATUS).eq(Constants.SURVEY_SENT))
                 .or(Condition.column(Survey$Table.STATUS).eq(Constants.SURVEY_COMPLETED))

--- a/app/src/main/java/org/eyeseetea/malariacare/database/model/Value.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/model/Value.java
@@ -48,6 +48,7 @@ public class Value extends BaseModel implements VisitableToSDK {
     /**
      * Reference to the question for this value (loaded lazily)
      */
+
     Question question;
 
     @Column
@@ -63,6 +64,21 @@ public class Value extends BaseModel implements VisitableToSDK {
      * Reference to the option of this value (loaded lazily)
      */
     Option option;
+    /**
+     * is conflict
+     */
+    @Column
+    Boolean conflict;
+
+    public Boolean getConflict() {
+        if(conflict==null)
+            return false;
+        return conflict;
+    }
+
+    public void setConflict(Boolean conflict) {
+        this.conflict = conflict;
+    }
 
     public Value() {
     }
@@ -223,6 +239,8 @@ public class Value extends BaseModel implements VisitableToSDK {
             return false;
         if (id_survey != null ? !id_survey.equals(value1.id_survey) : value1.id_survey != null)
             return false;
+        if (conflict != null ? !conflict.equals(value1.conflict) : value1.conflict != null)
+            return false;
         return !(id_option != null ? !id_option.equals(value1.id_option) : value1.id_option != null);
 
     }
@@ -234,6 +252,7 @@ public class Value extends BaseModel implements VisitableToSDK {
         result = 31 * result + (id_question != null ? id_question.hashCode() : 0);
         result = 31 * result + (id_survey != null ? id_survey.hashCode() : 0);
         result = 31 * result + (id_option != null ? id_option.hashCode() : 0);
+        result = 31 * result + (conflict != null ? conflict.hashCode() : 0);
         return result;
     }
 
@@ -245,6 +264,7 @@ public class Value extends BaseModel implements VisitableToSDK {
                 ", id_question=" + id_question +
                 ", id_survey=" + id_survey +
                 ", id_option=" + id_option +
+                ", conflict=" + conflict +
                 '}';
     }
 }

--- a/app/src/main/java/org/eyeseetea/malariacare/database/utils/feedback/QuestionFeedback.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/utils/feedback/QuestionFeedback.java
@@ -56,10 +56,16 @@ public class QuestionFeedback implements Feedback {
 
     @Override
     public boolean isPassed() {
-        if(this.value==null){
+        if(this.value==null || this.value.getConflict()){
             return false;
         }
         return this.value.getOption().getFactor()==1;
+    }
+
+    public boolean hasConflict(){
+        if(this.value!=null && this.value.getConflict())
+            return true;
+        return false;
     }
 
     /**
@@ -114,7 +120,9 @@ public class QuestionFeedback implements Feedback {
      */
     public int getGrade(){
         int msgId;
-        if(this.getOption()==null || this.getOption().isEmpty()){
+        if(value!=null && value.getConflict()){
+            msgId = R.string.feedback_info_conflict;
+        }else if(this.getOption()==null || this.getOption().isEmpty()){
             msgId = R.string.feedback_info_not_answered;
         }else {
             msgId = this.isPassed() ? R.string.feedback_info_passed : R.string.feedback_info_failed;
@@ -135,7 +143,7 @@ public class QuestionFeedback implements Feedback {
         if(this.getOption()==null || this.getOption().isEmpty()){
             textColor = R.color.amber;
         }else {
-            textColor=this.isPassed() ? R.color.green : R.color.red;
+            textColor=(this.isPassed() && value!=null && !this.value.getConflict())? R.color.green : R.color.red;
         }
         return textColor;
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardSentFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardSentFragment.java
@@ -368,7 +368,7 @@ public class DashboardSentFragment extends ListFragment {
 
         if (surveyReceiver == null) {
             surveyReceiver = new SurveyReceiver();
-            LocalBroadcastManager.getInstance(getActivity()).registerReceiver(surveyReceiver, new IntentFilter(SurveyService.ALL_SENT_OR_COMPLETED_SURVEYS_ACTION));
+            LocalBroadcastManager.getInstance(getActivity()).registerReceiver(surveyReceiver, new IntentFilter(SurveyService.ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION));
             LocalBroadcastManager.getInstance(getActivity()).registerReceiver(surveyReceiver, new IntentFilter(SurveyService.ALL_ORG_UNITS_AND_PROGRAMS_ACTION));
         }
     }
@@ -406,23 +406,21 @@ public class DashboardSentFragment extends ListFragment {
      * filter the surveys for last survey in org unit, and set surveysForGraphic for the statistics
      */
     public void reloadSentSurveys() {
-        List<Survey> surveys = (List<Survey>) Session.popServiceValue(SurveyService.ALL_SENT_OR_COMPLETED_SURVEYS_ACTION);
+        List<Survey> surveys = (List<Survey>) Session.popServiceValue(SurveyService.ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION);
         HashMap<String, Survey> orgUnits;
         orgUnits = new HashMap<>();
         oneSurveyForOrgUnit = new ArrayList<>();
 
         for (Survey survey : surveys) {
-            if (survey.isSent() || survey.isCompleted()) {
-                if (survey.getOrgUnit() != null) {
-                    if (!orgUnits.containsKey(survey.getTabGroup().getProgram().getUid()+survey.getOrgUnit().getUid())) {
-                        filterSurvey(orgUnits, survey);
-                    } else {
-                        Survey surveyMapped = orgUnits.get(survey.getTabGroup().getProgram().getUid()+survey.getOrgUnit().getUid());
-                        Log.d(TAG,"reloadSentSurveys check NPE \tsurveyMapped:"+surveyMapped+"\tsurvey:"+survey);
-                        Log.d(TAG,"reloadSentSurveys check completionDate\tsurveyMapped:"+surveyMapped.getCompletionDate()+"\tsurvey:"+survey.getCompletionDate());
-                        if (surveyMapped.getCompletionDate().before(survey.getCompletionDate())) {
-                            orgUnits=filterSurvey(orgUnits, survey);
-                        }
+            if (survey.getOrgUnit() != null) {
+                if (!orgUnits.containsKey(survey.getTabGroup().getProgram().getUid()+survey.getOrgUnit().getUid())) {
+                    filterSurvey(orgUnits, survey);
+                } else {
+                    Survey surveyMapped = orgUnits.get(survey.getTabGroup().getProgram().getUid()+survey.getOrgUnit().getUid());
+                    Log.d(TAG,"reloadSentSurveys check NPE \tsurveyMapped:"+surveyMapped+"\tsurvey:"+survey);
+                    Log.d(TAG,"reloadSentSurveys check completionDate\tsurveyMapped:"+surveyMapped.getCompletionDate()+"\tsurvey:"+survey.getCompletionDate());
+                    if (surveyMapped.getCompletionDate().before(survey.getCompletionDate())) {
+                        orgUnits=filterSurvey(orgUnits, survey);
                     }
                 }
             }
@@ -496,7 +494,7 @@ public class DashboardSentFragment extends ListFragment {
         public void onReceive(Context context, Intent intent) {
             Log.d(TAG, "onReceive");
             //Listening only intents from this method
-            if (SurveyService.ALL_SENT_OR_COMPLETED_SURVEYS_ACTION.equals(intent.getAction())) {
+            if (SurveyService.ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION.equals(intent.getAction())) {
                 reloadSentSurveys();
             }
             if(SurveyService.ALL_ORG_UNITS_AND_PROGRAMS_ACTION.equals(intent.getAction())){

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/MonitorFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/MonitorFragment.java
@@ -132,7 +132,7 @@ public class MonitorFragment extends Fragment {
 
         if (surveyReceiver == null) {
             surveyReceiver = new SurveyReceiver();
-            LocalBroadcastManager.getInstance(getActivity()).registerReceiver(surveyReceiver, new IntentFilter(SurveyService.ALL_SENT_OR_COMPLETED_SURVEYS_ACTION));
+            LocalBroadcastManager.getInstance(getActivity()).registerReceiver(surveyReceiver, new IntentFilter(SurveyService.ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION));
         }
     }
     /**

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/dashboard/AAssessmentAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/dashboard/AAssessmentAdapter.java
@@ -78,9 +78,15 @@ public abstract class AAssessmentAdapter extends ADashboardAdapter implements ID
             Date completionDate = survey.getCompletionDate();
             SimpleDateFormat format = new SimpleDateFormat("MM/dd/yyyy");
             sentDate.setText(format.format(completionDate));
-            sentScore.setText(String.format("%.1f %%", survey.getMainScore()));
-            int colorId=LayoutUtils.trafficColor(survey.getMainScore());
-            sentScore.setTextColor(getContext().getResources().getColor(colorId));
+            if(survey.hasConflict()){
+                sentScore.setText((getContext().getResources().getString(R.string.feedback_info_conflict)).toUpperCase());
+                sentScore.setTextColor(getContext().getResources().getColor(R.color.darkRed));
+            }
+            else {
+                sentScore.setText(String.format("%.1f %%",survey.getMainScore()));
+                int colorId=LayoutUtils.trafficColor(survey.getMainScore());
+                sentScore.setTextColor(getContext().getResources().getColor(colorId));
+            }
         } else {
             //Status Cell
             ((CustomTextView) rowView.findViewById(R.id.score)).setText(getStatus(survey));

--- a/app/src/main/java/org/eyeseetea/malariacare/services/SurveyService.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/services/SurveyService.java
@@ -72,7 +72,7 @@ public class SurveyService extends IntentService {
     /**
      * Name of 'list completed' action
      */
-    public static final String ALL_SENT_OR_COMPLETED_SURVEYS_ACTION ="org.eyeseetea.malariacare.services.SurveyService.ALL_SENT_OR_COMPLETED_SURVEYS_ACTION";
+    public static final String ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION ="org.eyeseetea.malariacare.services.SurveyService.ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION";
 
     /**
      * Name of 'reload' action which returns both lists (unsent, sent)
@@ -177,8 +177,8 @@ public class SurveyService extends IntentService {
             case ALL_IN_PROGRESS_SURVEYS_ACTION:
                 getAllInProgressSurveys();
                 break;
-            case ALL_SENT_OR_COMPLETED_SURVEYS_ACTION:
-                getAllSentOrCompletedSurveys();
+            case ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION:
+                getAllSentCompletedOrConflictSurveys();
                 break;
             case ALL_COMPLETED_SURVEYS_ACTION:
                 getAllCompletedSurveys();
@@ -305,7 +305,7 @@ public class SurveyService extends IntentService {
         List<Survey> completedUnsentSurveys=Survey.getAllCompletedUnsentSurveys();
         List<Survey> unsentSurveys=Survey.getAllInProgressSurveys();
         List<Survey> sentSurveys=Survey.getAllSentSurveys();
-        List<Survey> sentAndCompletedSurveys=Survey.getAllSentOrCompletedSurveys();
+        List<Survey> sentCompletedOrConflictSurveys=Survey.getAllSentCompletedOrConflictSurveys();
         for(Survey survey:unsentSurveys){
                 survey.getAnsweredQuestionRatio();
         }
@@ -328,7 +328,7 @@ public class SurveyService extends IntentService {
         Session.putServiceValue(ALL_MONITOR_DATA_ACTION,monitorMap);
         Session.putServiceValue(ALL_IN_PROGRESS_SURVEYS_ACTION, unsentSurveys);
         Session.putServiceValue(ALL_COMPLETED_SURVEYS_ACTION, completedUnsentSurveys);
-        Session.putServiceValue(ALL_SENT_OR_COMPLETED_SURVEYS_ACTION, sentAndCompletedSurveys);
+        Session.putServiceValue(ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION, sentCompletedOrConflictSurveys);
         Session.putServiceValue(PLANNED_SURVEYS_ACTION, PlannedItemBuilder.getInstance().buildPlannedItems());
         Session.putServiceValue(ALL_ORG_UNITS_AND_PROGRAMS_ACTION,orgUnitsAndPrograms);
         Session.putServiceValue(ALL_PROGRAMS_ACTION,Program.getAllPrograms());
@@ -340,7 +340,7 @@ public class SurveyService extends IntentService {
         LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(ALL_MONITOR_DATA_ACTION));
         LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(ALL_IN_PROGRESS_SURVEYS_ACTION));
         LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(ALL_COMPLETED_SURVEYS_ACTION));
-        LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(ALL_SENT_OR_COMPLETED_SURVEYS_ACTION));
+        LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION));
         LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(PLANNED_SURVEYS_ACTION));
         LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(ALL_ORG_UNITS_AND_PROGRAMS_ACTION));
 
@@ -361,19 +361,19 @@ public class SurveyService extends IntentService {
     }
 
     /**
-     * Selects all sent surveys from database
+     * Selects all sent completed or conlfict surveys from database (for improve )
      */
-    private void getAllSentOrCompletedSurveys(){
-        Log.d(TAG,"getAllSentOrCompletedSurveys (Thread:"+Thread.currentThread().getId()+")");
+    private void getAllSentCompletedOrConflictSurveys(){
+        Log.d(TAG,"getAllSentCompletedOrConflictSurveys (Thread:"+Thread.currentThread().getId()+")");
 
         //Select surveys from sql
-        List<Survey> surveys = Survey.getAllSentOrCompletedSurveys();
+        List<Survey> surveys = Survey.getAllSentCompletedOrConflictSurveys();
 
         //Since intents does NOT admit NON serializable as values we use Session instead
-        Session.putServiceValue(ALL_SENT_OR_COMPLETED_SURVEYS_ACTION,surveys);
+        Session.putServiceValue(ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION,surveys);
 
         //Returning result to anyone listening
-        Intent resultIntent= new Intent(ALL_SENT_OR_COMPLETED_SURVEYS_ACTION);
+        Intent resultIntent= new Intent(ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION);
         LocalBroadcastManager.getInstance(this).sendBroadcast(resultIntent);
     }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/Constants.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/Constants.java
@@ -40,7 +40,8 @@ public class Constants {
             SURVEY_IN_PROGRESS = 0,
             SURVEY_COMPLETED = 1,
             SURVEY_SENT = 2,
-            SURVEY_HIDE = 3;
+            SURVEY_HIDE = 3,
+            SURVEY_CONFLICT = 4;
 
     //############# OPERATION TYPE ##############
     public static final int OPERATION_TYPE_MATCH = 0,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,7 @@
     <string name="feedback_info_failed">FAIL</string>
     <string name="feedback_info_not_answered">NA</string>
     <string name="feedback_info_no_feedback">No feedback</string>
+    <string name="feedback_info_conflict">Conflict</string>
 
 
     <!-- future -->

--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-rm -rf DBFlowORM
-git clone git@github.com:EyeSeeTea/DBFlow.git DBFlowORM
-rm -rf sdk
-git clone -b 2.22_EyeSeeTea git@github.com:EyeSeeTea/dhis2-android-sdk.git sdk
+cd sdk
+git checkout 2.22_EyeSeeTea
+cd -
 cp -a DBFlowORM sdk


### PR DESCRIPTION
Closes #780
New features:
when the dataelement have a conflict:
The survey show "Conflict" text in the score.
The survey show in the feedbackfragment the value with "Conflict" text in the score
when the app push a survey with conflicts, it shows a dialog with the error, only one.


The import Summary is not return or saving the conflict, but the FailedItem table does it.
Saving(for example):
{"httpStatus":"Conflict","httpStatusCode":409,"status":"WARNING","message":"One more conflicts encountered, please check import summary.","response":{"responseType":"ImportSummaries","imported":29,"updated":0,"deleted":0,"ignored":1,"importSummaries":[{"responseType":"ImportSummary","status":"SUCCESS","importCount":{"imported":29,"updated":0,"ignored":1,"deleted":0},"conflicts":[{"object":"jIIYvQtD3zW","value":"value_not_numeric"}],"reference":"dpEkxlCkRIH","href":"https://hnqis-dev-staging.psi-mis.org/api/events/dpEkxlCkRIH"}]}}

I create the column "conflict" as boolean in the Value.class.
I save in this column if the Value has conflict, I saved it when the survey is converting to the sdk looking the sdk db in the FailedItem table.

This is needed for show the conflict in the improve tab(the survey with conflict) and in the feedback(the value with conflict)

I think other options like: Create Conflict Pojo, and save all the JSON Values, or create a table(ValueConflict), but i think add a column in the value is more fast for this feature.

Other thing. I was trying to make the test, but i can´t simulate the bad dataelement type. I am not sure if continue trying to finish the test tomorrow.