### PR TITLE
Add _forward_control dataelement without remove _push dataelement

### DIFF
--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -31,7 +31,8 @@
     <string name="main_score_a" translatable="false">TgCWRlUXbca</string>
     <string name="main_score_b" translatable="false">zckZqXOQRHT</string>
     <string name="main_score_c" translatable="false">DBUwlPCO0Hd</string>
-    <string name="forward_order" translatable="false">d1At6VgPNA6</string>
+    <string name="_push" translatable="false">d1At6VgPNA6</string>
+    <string name="forward_order" translatable="false">FEkGksxhOpH</string>
     <string name="forward_order_value" translatable="false">9999</string>
 
 

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="main_score_a" translatable="false">TgCWRlUXbca</string>
     <string name="main_score_b" translatable="false">zckZqXOQRHT</string>
     <string name="main_score_c" translatable="false">DBUwlPCO0Hd</string>
-    <string name="_push" translatable="false">d1At6VgPNA6</string>
+    <string name="push" translatable="false">d1At6VgPNA6</string>
     <string name="forward_order" translatable="false">FEkGksxhOpH</string>
     <string name="forward_order_value" translatable="false">9999</string>
 

--- a/app/src/hnqis/res/values/strings.xml
+++ b/app/src/hnqis/res/values/strings.xml
@@ -31,7 +31,6 @@
     <string name="main_score_a" translatable="false">TgCWRlUXbca</string>
     <string name="main_score_b" translatable="false">zckZqXOQRHT</string>
     <string name="main_score_c" translatable="false">DBUwlPCO0Hd</string>
-    <string name="push" translatable="false">d1At6VgPNA6</string>
     <string name="forward_order" translatable="false">FEkGksxhOpH</string>
     <string name="forward_order_value" translatable="false">9999</string>
 

--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -70,7 +70,6 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
     String mainScoreBUID;
     String mainScoreCUID;
     String forwardOrderUID;
-    String pushUID;
 
     /**
      * List of surveys that are going to be pushed
@@ -105,7 +104,6 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
         mainScoreBUID=context.getString(R.string.main_score_b);
         mainScoreCUID=context.getString(R.string.main_score_c);
         forwardOrderUID=context.getString(R.string.forward_order);
-        pushUID =context.getString(R.string._push);
         surveys = new ArrayList<>();
         events = new ArrayList<>();
     }
@@ -225,9 +223,6 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
 
         //Forward Order
         buildAndSaveDataValue(forwardOrderUID, context.getString(R.string.forward_order_value));
-
-        //_Push
-        buildAndSaveDataValue(pushUID, context.getString(R.string.forward_order_value));
     }
 
     private void buildAndSaveDataValue(String UID, String value){

--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -19,17 +19,14 @@
 
 package org.eyeseetea.malariacare.database.iomodules.dhis.exporter;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.location.Location;
 import android.util.Log;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.language.Select;
 
 import org.eyeseetea.malariacare.DashboardActivity;
-import org.eyeseetea.malariacare.ProgressActivity;
 import org.eyeseetea.malariacare.R;
 import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.EventExtended;
 import org.eyeseetea.malariacare.database.model.CompositeScore;
@@ -39,7 +36,6 @@ import org.eyeseetea.malariacare.database.model.Value;
 import org.eyeseetea.malariacare.database.utils.LocationMemory;
 import org.eyeseetea.malariacare.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.database.utils.Session;
-import org.eyeseetea.malariacare.database.utils.planning.SurveyPlanner;
 import org.eyeseetea.malariacare.layout.score.ScoreRegister;
 import org.eyeseetea.malariacare.utils.Constants;
 import org.eyeseetea.malariacare.utils.Utils;
@@ -54,7 +50,6 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,7 +70,7 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
     String mainScoreBUID;
     String mainScoreCUID;
     String forwardOrderUID;
-    String _push;
+    String pushUID;
 
     /**
      * List of surveys that are going to be pushed
@@ -110,7 +105,7 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
         mainScoreBUID=context.getString(R.string.main_score_b);
         mainScoreCUID=context.getString(R.string.main_score_c);
         forwardOrderUID=context.getString(R.string.forward_order);
-        _push=context.getString(R.string._push);
+        pushUID =context.getString(R.string._push);
         surveys = new ArrayList<>();
         events = new ArrayList<>();
     }
@@ -232,7 +227,7 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
         buildAndSaveDataValue(forwardOrderUID, context.getString(R.string.forward_order_value));
 
         //_Push
-        buildAndSaveDataValue(_push, context.getString(R.string.forward_order_value));
+        buildAndSaveDataValue(pushUID, context.getString(R.string.forward_order_value));
     }
 
     private void buildAndSaveDataValue(String UID, String value){

--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -75,6 +75,7 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
     String mainScoreBUID;
     String mainScoreCUID;
     String forwardOrderUID;
+    String _push;
 
     /**
      * List of surveys that are going to be pushed
@@ -109,6 +110,7 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
         mainScoreBUID=context.getString(R.string.main_score_b);
         mainScoreCUID=context.getString(R.string.main_score_c);
         forwardOrderUID=context.getString(R.string.forward_order);
+        _push=context.getString(R.string._push);
         surveys = new ArrayList<>();
         events = new ArrayList<>();
     }
@@ -228,6 +230,9 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
 
         //Forward Order
         buildAndSaveDataValue(forwardOrderUID, context.getString(R.string.forward_order_value));
+
+        //_Push
+        buildAndSaveDataValue(_push, context.getString(R.string.forward_order_value));
     }
 
     private void buildAndSaveDataValue(String UID, String value){


### PR DESCRIPTION
closes #802 
@ifoche The forward_order uid  was changed from [_forward_order  ](https://hnqis-dev-ci.psi-mis.org/api/dataElements/FEkGksxhOpH) to [_push ](https://hnqis-dev-ci.psi-mis.org/api/dataElements/d1At6VgPNA6)  in our strings.xml. 

(Some difference in the dataelement controls, the _push is a text value, and _forward_order is int and zeroPoditiveInt)

Related:
 https://github.com/EyeSeeTea/malariapp/commit/10fe14f5ec7179028c88f042c8f0c34db728d5d6
https://github.com/EyeSeeTea/malariapp/issues/600

the 9999 value was saved in _push. 

I added the old forward_order, (and it is setting as 9999 now), but i dont know what is _push control dataelement.

should i remove _push dataelement control?