### PR TITLE
push from assess only make push of the first assess

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
@@ -191,7 +191,7 @@ public class DashboardUnsentFragment extends ListFragment {
                     if(Float.valueOf(100 * surveyAnsweredRatio.getCompulsoryRatio()).intValue()>=100) {
                         survey.setCompleteSurveyState();
                         mCallback.alertOnComplete(survey);
-                        removeSurvey(survey);
+                        removeSurveyFromAdapter(survey);
                         reloadToSend();
                     }
                     else{
@@ -201,7 +201,7 @@ public class DashboardUnsentFragment extends ListFragment {
                 else {
                     survey.setCompleteSurveyState();
                     mCallback.alertOnComplete(survey);
-                    removeSurvey(survey);
+                    removeSurveyFromAdapter(survey);
                     reloadToSend();
                 }
                 return true;
@@ -215,7 +215,7 @@ public class DashboardUnsentFragment extends ListFragment {
                                 //this method create a new survey geting the getScheduledDate date of the oldsurvey, and remove it.
                                 Survey survey=(Survey) adapter.getItem(selectedPosition - 1);
                                 SurveyPlanner.getInstance().deleteSurveyAndBuildNext(survey);
-                                removeSurvey(survey);
+                                removeSurveyFromAdapter(survey);
                             }
                         })
                         .setNegativeButton(android.R.string.no, null).create().show();
@@ -227,7 +227,7 @@ public class DashboardUnsentFragment extends ListFragment {
     }
 
     //Remove survey from the list and reload list.
-    private void removeSurvey(Survey survey) {
+    private void removeSurveyFromAdapter(Survey survey) {
         adapter.remove(survey);
         adapter.notifyDataSetChanged();
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
@@ -191,7 +191,7 @@ public class DashboardUnsentFragment extends ListFragment {
                     if(Float.valueOf(100 * surveyAnsweredRatio.getCompulsoryRatio()).intValue()>=100) {
                         survey.setCompleteSurveyState();
                         mCallback.alertOnComplete(survey);
-                        reloadData();
+                        removeSurvey(survey);
                     }
                     else{
                         mCallback.dialogCompulsoryQuestionIncompleted();
@@ -200,7 +200,7 @@ public class DashboardUnsentFragment extends ListFragment {
                 else {
                     survey.setCompleteSurveyState();
                     mCallback.alertOnComplete(survey);
-                    reloadData();
+                    removeSurvey(survey);
                 }
                 return true;
             case R.id.option_delete:
@@ -211,8 +211,9 @@ public class DashboardUnsentFragment extends ListFragment {
                         .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface arg0, int arg1) {
                                 //this method create a new survey geting the getScheduledDate date of the oldsurvey, and remove it.
-                                SurveyPlanner.getInstance().deleteSurveyAndBuildNext((Survey) adapter.getItem(selectedPosition - 1));
-                                reloadData();
+                                Survey survey=(Survey) adapter.getItem(selectedPosition - 1);
+                                SurveyPlanner.getInstance().deleteSurveyAndBuildNext(survey);
+                                removeSurvey(survey);
                             }
                         })
                         .setNegativeButton(android.R.string.no, null).create().show();
@@ -221,6 +222,12 @@ public class DashboardUnsentFragment extends ListFragment {
             default:
                 return super.onContextItemSelected(item);
         }
+    }
+
+    //Remove survey from the list and reload list.
+    private void removeSurvey(Survey survey) {
+        adapter.remove(survey);
+        adapter.notifyDataSetChanged();
     }
 
     public void reloadData(){

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
@@ -332,8 +332,6 @@ public class DashboardUnsentFragment extends ListFragment {
     public void reloadInProgressSurveys(){
         List<Survey> surveysInProgressFromService = (List<Survey>) Session.popServiceValue(SurveyService.ALL_IN_PROGRESS_SURVEYS_ACTION);
         reloadSurveys(surveysInProgressFromService);
-        //set alarm if is malariaapp question
-        reloadCompletedSurveys();
     }
 
     public void reloadCompletedSurveys(){

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
@@ -192,6 +192,7 @@ public class DashboardUnsentFragment extends ListFragment {
                         survey.setCompleteSurveyState();
                         mCallback.alertOnComplete(survey);
                         removeSurvey(survey);
+                        reloadToSend();
                     }
                     else{
                         mCallback.dialogCompulsoryQuestionIncompleted();
@@ -201,6 +202,7 @@ public class DashboardUnsentFragment extends ListFragment {
                     survey.setCompleteSurveyState();
                     mCallback.alertOnComplete(survey);
                     removeSurvey(survey);
+                    reloadToSend();
                 }
                 return true;
             case R.id.option_delete:

--- a/app/src/main/java/org/eyeseetea/malariacare/services/PushService.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/services/PushService.java
@@ -87,13 +87,11 @@ public class PushService extends IntentService {
         Log.d(TAG, "pushAllPendingSurveys (Thread:" + Thread.currentThread().getId() + ")");
 
         //Select surveys from sql
-        List<Survey> surveys = Survey.getAllUnsentUnplannedSurveys();
+        List<Survey> surveys = Survey.getAllCompletedSurveys();
 
         if(surveys!=null && !surveys.isEmpty()){
             for(Survey survey : surveys){
-                if(survey.isCompleted()){
                     sendPush(survey);
-                }
             }
         }
     }


### PR DESCRIPTION
Closes #833 
@ifoche I think all is solved but maybe not, i preefer explain more:

Problem removing bad items:
The problem was we reload the list from the SurveyService, and it take more time than the user next action. Remove the item from the adapter without innecesary SurveyService fixed it.

Problem with sent only one survey.
"Apparently, when you try to push from the assess tab a survey, and you have several there, the push is done on the first one of the list, regardless what you clicked"
I think is the same of the other point.
I´m not sure if i reproduce that problem. I´m not sure 100% about what list are you talking about. Do you talk about listfragment or survey with status as completed(to be send)?
 
When you mark as completed a survey, this will be send in background, if you mark more surveys they will send in the next loop (i checked it debugging and stop the application before push for add more than 1 surveys, becouse the push is more fast than me adding new surveys as completed, and all was sent).
I revised it too.


And one suggestion, maybe is good idea create a new user test with more programs(and one with compulsory questions)? I can´t test it at this moment with test users.
