### PR TITLE
Set the question parent background more darkness

### DIFF
--- a/app/src/main/res/values/color.xml
+++ b/app/src/main/res/values/color.xml
@@ -12,7 +12,7 @@
     <color name="navy_blue">#FF1F70C3</color>
     <color name="dark_navy_blue">#FF1D5288</color>
     <color name="light_grey">#FFE5E5E5</color>
-    <color name="parentColor">#EFF1D5</color>
+    <color name="parentColor">#d8dac1</color>
     <color name="textFieldColor">#BEBEBE</color>
     <color name="darkGrey">#565656</color>
     <color name="formFooter">#429470</color>


### PR DESCRIPTION
closes #854 

If i add make more yellow-dark the question parents they dont look good.
I added only a bit of darker(without add yellow). But looks more like grey now.
I tried a lot of colors, but the headers(more dark yellow), and the buttons(more dark yellow), and the text(black) don´t help to look best the question parents..