### PR TITLE
Review time completion feedback

### DIFF
--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/AssessAction/AssessCompleteGoToImprove.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/AssessAction/AssessCompleteGoToImprove.java
@@ -104,7 +104,7 @@ public class AssessCompleteGoToImprove {
         waitForPull(DEFAULT_WAIT_FOR_PULL);
         startSurvey(SDKTestUtils.TEST_FACILITY_1_IDX, SDKTestUtils.TEST_CC);
         //randomResponseNumber is used to randomize the survey answers to obtain a different main score between tests.
-        int randomResponseNumber=2 + (int)(Math.random() * 7);
+        int randomResponseNumber=2 + (int)(Math.random() * 15);
         fillSurvey(randomResponseNumber, "Yes");
         Date completionDate= Survey.findById(SDKTestUtils.getSurveyId()).getCompletionDate();
 

--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/AssessAction/AssessCompleteGoToImprove.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/AssessAction/AssessCompleteGoToImprove.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2016.
+ *
+ * This file is part of QA App.
+ *
+ *  Health Network QIS App is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Health Network QIS App is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eyeseetea.malariacare.test.AssessAction;
+
+import android.support.test.espresso.AmbiguousViewMatcherException;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.IdlingResource;
+import android.support.test.espresso.matcher.BoundedMatcher;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
+
+import org.eyeseetea.malariacare.LoginActivity;
+import org.eyeseetea.malariacare.R;
+import org.eyeseetea.malariacare.database.model.Survey;
+import org.eyeseetea.malariacare.test.utils.ElapsedTimeIdlingResource;
+import org.eyeseetea.malariacare.test.utils.SDKTestUtils;
+import org.hamcrest.Description;
+import org.hamcrest.Matchers;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.hasContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withChild;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withTagKey;
+import static android.support.test.espresso.matcher.ViewMatchers.withTagValue;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.DEFAULT_WAIT_FOR_PULL;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.HNQIS_DEV_CI;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.TEST_PASSWORD_WITH_PERMISSION;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.TEST_USERNAME_WITH_PERMISSION;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.fillSurvey;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.login;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.startSurvey;
+import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.waitForPull;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.comparesEqualTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.AllOf.allOf;
+
+/**
+ * Created by idelcano on 21/03/2016.
+ */
+@RunWith(AndroidJUnit4.class)
+public class AssessCompleteGoToImprove {
+
+    private static final String TAG="AssessActionTest";
+
+    @Rule
+    public ActivityTestRule<LoginActivity> mActivityRule = new ActivityTestRule<>(
+            LoginActivity.class);
+
+    @Before
+    public void setup(){
+        //force init go to logging activity.
+        SDKTestUtils.goToLogin();
+        //set the test limit( and throw exception if the time is exceded)
+        SDKTestUtils.setTestTimeoutSeconds(SDKTestUtils.DEFAULT_TEST_TIME_LIMIT);
+    }
+
+    @AfterClass
+    public static void exitApp() throws Exception {
+        SDKTestUtils.exitApp();
+    }
+
+    @Test
+    public void assessCompleteAndGoImprove(){
+        //GIVEN
+        login(HNQIS_DEV_CI, TEST_USERNAME_WITH_PERMISSION, TEST_PASSWORD_WITH_PERMISSION);
+        waitForPull(DEFAULT_WAIT_FOR_PULL);
+        startSurvey(SDKTestUtils.TEST_FACILITY_1_IDX, SDKTestUtils.TEST_CC);
+        //randomResponseNumber is used to randomize the survey answers to obtain a different main score between tests.
+        int randomResponseNumber=2 + (int)(Math.random() * 7);
+        fillSurvey(randomResponseNumber, "Yes");
+
+        //WHEN
+        Long idSurvey=SDKTestUtils.markCompleteAndGoImprove();
+        final Survey survey = Survey.findById(idSurvey);
+
+
+        //THEN
+        IdlingResource idlingResource = new ElapsedTimeIdlingResource(5 * 1000);
+        Espresso.registerIdlingResources(idlingResource);
+        try {
+            onView(withText(String.format("%.1f %%", survey.getMainScore()))).check(matches(isDisplayed()));
+        }catch(AmbiguousViewMatcherException e){
+            Log.d(TAG, "Multiple surveys have the same score " + String.format("%.1f %%", survey.getMainScore()));
+        }
+        //WHEN
+        if(survey.isCompleted())
+            onView(withText( "* "  + survey.getTabGroup().getProgram().getName())).check(matches(isDisplayed())).perform(click());
+        else
+            onView(withText("- "   + survey.getTabGroup().getProgram().getName())).check(matches(isDisplayed())).perform(click());
+        Espresso.unregisterIdlingResources(idlingResource);
+        //THEN
+
+        idlingResource = new ElapsedTimeIdlingResource(5 * 1000);
+        Espresso.registerIdlingResources(idlingResource);
+        //check if is in feedback
+        onView(withText(R.string.quality_of_care)).check(matches(isDisplayed()));
+        onView(withText(String.format("%.1f%%", survey.getMainScore()))).check(matches(isDisplayed()));
+        Espresso.unregisterIdlingResources(idlingResource);
+    }
+}

--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/AssessAction/AssessCompulsoryIncompleteTest.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/AssessAction/AssessCompulsoryIncompleteTest.java
@@ -83,7 +83,7 @@ public class AssessCompulsoryIncompleteTest {
             login(HNQIS_DEV_CI, TEST_USERNAME_WITH_PERMISSION, TEST_PASSWORD_WITH_PERMISSION);
             waitForPull(DEFAULT_WAIT_FOR_PULL);
         }
-        startSurvey(SDKTestUtils.TEST_FACILITY_1_IDX, SDKTestUtils.TEST_FACILITY_1_IDX);
+        startSurvey(SDKTestUtils.TEST_FACILITY_1_IDX, SDKTestUtils.TEST_IMCI);
         fillSurvey(12, "Yes");
 
         //WHEN

--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/AssessAction/AssessCompulsoryTest.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/AssessAction/AssessCompulsoryTest.java
@@ -89,7 +89,7 @@ public class AssessCompulsoryTest {
             login(HNQIS_DEV_CI, TEST_USERNAME_WITH_PERMISSION, TEST_PASSWORD_WITH_PERMISSION);
             waitForPull(DEFAULT_WAIT_FOR_PULL);
         }
-        startSurvey(SDKTestUtils.TEST_FACILITY_1_IDX, SDKTestUtils.TEST_FACILITY_1_IDX);
+        startSurvey(SDKTestUtils.TEST_FACILITY_1_IDX, SDKTestUtils.TEST_IMCI);
         fillCompulsorySurvey(13, "Yes");
 
         //WHEN

--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/push/PushOKTest.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/push/PushOKTest.java
@@ -43,7 +43,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static junit.framework.Assert.assertTrue;
 import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.DEFAULT_WAIT_FOR_PULL;
 import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.HNQIS_DEV_CI;
-import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.HNQIS_DEV_STAGING;
 import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.TEST_PASSWORD_WITH_PERMISSION;
 import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.TEST_USERNAME_WITH_PERMISSION;
 import static org.eyeseetea.malariacare.test.utils.SDKTestUtils.fillSurvey;
@@ -85,16 +84,25 @@ public class PushOKTest {
         login(HNQIS_DEV_CI, TEST_USERNAME_WITH_PERMISSION, TEST_PASSWORD_WITH_PERMISSION);
         waitForPull(DEFAULT_WAIT_FOR_PULL);
         startSurvey(SDKTestUtils.TEST_FACILITY_1_IDX, SDKTestUtils.TEST_FAMILY_PLANNING_IDX);
+        long eventCount = SDKTestUtils.getEventCount();
         fillSurvey(7, "No");
         Long idSurvey=markInProgressAsCompleted();
 
         //then: Survey is pushed (UID)
         Log.d(TAG, "Session user ->"+ Session.getUser());
-        Survey survey=waitForPush(SDKTestUtils.DEFAULT_WAIT_FOR_PUSH,idSurvey);
+        Survey survey=waitForPush(SDKTestUtils.DEFAULT_WAIT_FOR_PUSH*1000,idSurvey);
+
+
+
+        IdlingResource idlingResource = new ElapsedTimeIdlingResource(SDKTestUtils.DEFAULT_WAIT_FOR_PUSH *1000);
+        Espresso.registerIdlingResources(idlingResource);
+        Log.d(TAG,survey.toString());
+        Espresso.unregisterIdlingResources(idlingResource);
+
         assertTrue(survey.getEventUid()!=null);
+        assertTrue(eventCount +1 == SDKTestUtils.getEventCount());
 
         //then: Row is gone
         onView(withId(R.id.score)).check(doesNotExist());
     }
-
 }

--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/utils/SDKTestUtils.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/utils/SDKTestUtils.java
@@ -48,6 +48,7 @@ import org.eyeseetea.malariacare.database.model.Survey;
 import org.eyeseetea.malariacare.database.model.Survey$Table;
 import org.eyeseetea.malariacare.utils.Constants;
 import org.hamcrest.Matchers;
+import org.hisp.dhis.android.sdk.persistence.models.Event;
 import org.hisp.dhis.android.sdk.persistence.models.OrganisationUnit;
 import org.hisp.dhis.android.sdk.persistence.models.OrganisationUnit$Table;
 import org.hisp.dhis.android.sdk.persistence.models.OrganisationUnitDataSet;
@@ -79,7 +80,7 @@ public class SDKTestUtils {
 
     private static final String TAG = "TestingUtils";
     public static final int DEFAULT_WAIT_FOR_PULL = 40;
-    public static final int DEFAULT_WAIT_FOR_PUSH = 40;
+    public static final int DEFAULT_WAIT_FOR_PUSH = 50;
     public static final int DEFAULT_TEST_TIME_LIMIT = 180;
 
     public static final String HNQIS_DEV_STAGING = "https://hnqis-dev-staging.psi-mis.org";
@@ -365,6 +366,11 @@ public class SDKTestUtils {
         return new Select().all().from(org.hisp.dhis.android.sdk.persistence.models.Event.class).queryList();
     }
 
+    public static long getEventCount(){
+        return new Select().count()
+                .from(Event.class)
+                .count();
+    }
     public static Activity getActivityInstance() {
         final Activity[] activity = new Activity[1];
         Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();

--- a/app/src/androidTest/java/org/eyeseetea/malariacare/test/utils/SDKTestUtils.java
+++ b/app/src/androidTest/java/org/eyeseetea/malariacare/test/utils/SDKTestUtils.java
@@ -91,6 +91,10 @@ public class SDKTestUtils {
     public static final String TEST_PASSWORD_WITH_PERMISSION = "testP3rmission";
 
     public static final int TEST_FACILITY_1_IDX=1;
+    public static final int TEST_FACILITY_2_IDX=2;
+
+    public static final int TEST_IMCI=1;
+    public static final int TEST_CC=2;
     public static final int TEST_FAMILY_PLANNING_IDX=3;
 
     public static final String MARK_AS_COMPLETED = "Mark as completed";
@@ -248,6 +252,22 @@ public class SDKTestUtils {
         return idSurvey;
     }
 
+    public static Long markCompleteAndGoImprove() {
+        Long idSurvey = getSurveyId();
+
+        //when: Mark as completed
+        onView(withId(R.id.score)).perform(click());
+        onView(withText(MARK_AS_COMPLETED)).perform(click());
+        onView(withText(android.R.string.ok)).perform(click());
+
+        IdlingResource idlingResource = new ElapsedTimeIdlingResource(5 * 1000);
+        Espresso.registerIdlingResources(idlingResource);
+
+        onView(withTagValue(Matchers.is((Object) getActivityInstance().getApplicationContext().getString(R.string.tab_tag_improve)))).perform(click());
+
+        Espresso.unregisterIdlingResources(idlingResource);
+        return idSurvey;
+    }
 
 
     public static Long markAsCompleteCompulsory() {

--- a/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/DashboardActivity.java
@@ -158,7 +158,7 @@ public class DashboardActivity extends BaseActivity implements DashboardUnsentFr
                         setActionBarDashboard();
                     }
                     if(!isMoveToFeedback)
-                        sentFragment.reloadData();
+                        initImprove();
                 } else if (tabId.equalsIgnoreCase(getResources().getString(R.string.tab_tag_monitor))) {
                     currentTabName=getString(R.string.monitor);
                     tabHost.getCurrentTabView().setBackgroundColor(getResources().getColor(R.color.tab_green_monitor));
@@ -284,8 +284,8 @@ public class DashboardActivity extends BaseActivity implements DashboardUnsentFr
             sentFragment = new DashboardSentFragment();
             sentFragment.setArguments(getIntent().getExtras());
             sentFragment.registerSurveysReceiver();
-            replaceListFragment(R.id.dashboard_completed_container, sentFragment);
             sentFragment.reloadData();
+            replaceListFragment(R.id.dashboard_completed_container, sentFragment);
         }
     }
 

--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -243,6 +243,7 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
      */
     private void updateSurvey(List<CompositeScore> compositeScores){
         currentSurvey.setMainScore(ScoreRegister.calculateMainScore(compositeScores));
+        currentSurvey.setStatus(Constants.SURVEY_SENT);
         currentSurvey.setCompletionDate(completionDate);
         currentSurvey.setEventUid(currentEvent.getUid());
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -289,9 +289,9 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
             FailedItem failedItem= hasConflict(iEvent.getLocalId());
             if(hasImportSummaryErrors(importSummary) || failedItem!=null){
                 //Some error happened -> move back to completed
-                iSurvey.setStatus(Constants.SURVEY_COMPLETED);
-                iSurvey.setEventUid(null);
                 if(failedItem!=null) {
+                    iSurvey.setStatus(Constants.SURVEY_COMPLETED);
+                    iSurvey.setEventUid(null);
                     ImportSummary importSummary1=failedItem.getImportSummary();
                     List<String> failedUids=getFailedUidQuestion(failedItem.getErrorMessage());
                     for(String uid:failedUids) {

--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/PushController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/PushController.java
@@ -156,7 +156,7 @@ public class PushController {
                     postProgress(context.getString(R.string.progress_push_updating_survey));
                     Log.d(TAG, "Updating pushed survey data...");
                     converter.saveSurveyStatus(getImportSummaryMap(result));
-                    Log.d(TAG, "PUSH process...OK");
+                    Log.d(TAG, "PUSH process...Finish");
                 }catch (Exception ex){
                     Log.e(TAG,"onSendDataFinished: "+ex.getLocalizedMessage());
                     postException(ex);

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardSentFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardSentFragment.java
@@ -147,9 +147,7 @@ public class DashboardSentFragment extends ListFragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         Log.d(TAG, "onActivityCreated");
         super.onActivityCreated(savedInstanceState);
-
-        hideContainer();
-        //Loading...
+        //hide list
         if(isAdded())
             setListShown(false);
         initAdapter();
@@ -490,13 +488,6 @@ public class DashboardSentFragment extends ListFragment {
         return orgUnits;
     }
 
-    public void showContainer(){
-        getActivity().findViewById(R.id.dashboard_completed_container).setVisibility(View.VISIBLE);
-    }
-    public void hideContainer(){
-        getActivity().findViewById(R.id.dashboard_completed_container).setVisibility(View.GONE);
-    }
-
     /**
      * Inner private class that receives the result from the service
      */
@@ -533,7 +524,8 @@ public class DashboardSentFragment extends ListFragment {
         @Override
         protected void onPostExecute(Void result) {
             initFilters();
-            showContainer();
+            if(isAdded())
+                setListShown(true);
         }
 
         @Override

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
@@ -240,9 +240,9 @@ public class DashboardUnsentFragment extends ListFragment {
     public void reloadToSend(){
         //Reload data using service
         Intent surveysIntent=new Intent(getActivity(), SurveyService.class);
+        surveysIntent.putExtra(SurveyService.SERVICE_METHOD, SurveyService.ALL_COMPLETED_SURVEYS_ACTION);
         //Reload the dashboardsentfragment surveys too
         surveysIntent.putExtra(SurveyService.SERVICE_METHOD, SurveyService.ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION);
-        surveysIntent.putExtra(SurveyService.SERVICE_METHOD, SurveyService.ALL_COMPLETED_SURVEYS_ACTION);
         getActivity().startService(surveysIntent);
     }
     @Override

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
@@ -240,6 +240,8 @@ public class DashboardUnsentFragment extends ListFragment {
     public void reloadToSend(){
         //Reload data using service
         Intent surveysIntent=new Intent(getActivity(), SurveyService.class);
+        //Reload the dashboardsentfragment surveys too
+        surveysIntent.putExtra(SurveyService.SERVICE_METHOD, SurveyService.ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION);
         surveysIntent.putExtra(SurveyService.SERVICE_METHOD, SurveyService.ALL_COMPLETED_SURVEYS_ACTION);
         getActivity().startService(surveysIntent);
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/fragments/DashboardUnsentFragment.java
@@ -241,8 +241,6 @@ public class DashboardUnsentFragment extends ListFragment {
         //Reload data using service
         Intent surveysIntent=new Intent(getActivity(), SurveyService.class);
         surveysIntent.putExtra(SurveyService.SERVICE_METHOD, SurveyService.ALL_COMPLETED_SURVEYS_ACTION);
-        //Reload the dashboardsentfragment surveys too
-        surveysIntent.putExtra(SurveyService.SERVICE_METHOD, SurveyService.ALL_SENT_OR_COMPLETED_OR_CONFLICT_SURVEYS_ACTION);
         getActivity().startService(surveysIntent);
     }
     @Override

--- a/app/src/main/java/org/eyeseetea/malariacare/network/PushClient.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/network/PushClient.java
@@ -42,6 +42,7 @@ import org.eyeseetea.malariacare.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.database.utils.Session;
 import org.eyeseetea.malariacare.receivers.AlarmPushReceiver;
 import org.eyeseetea.malariacare.services.SurveyService;
+import org.eyeseetea.malariacare.utils.Utils;
 import org.json.JSONObject;
 
 import java.io.IOException;
@@ -104,13 +105,13 @@ public class PushClient {
     }
 
     public void pushSDK() {
-        if (isNetworkAvailable()) {
+        if (Utils.isNetworkAvailable()) {
             malariaSdkPush();
         }
     }
 
     public PushResult pushAPI() {
-        if (isNetworkAvailable()) {
+        if (Utils.isNetworkAvailable()) {
                return malariaApiPush();
         }
         return new PushResult();
@@ -205,22 +206,6 @@ public class PushClient {
         Intent surveysIntent=new Intent(applicationContext, SurveyService.class);
         surveysIntent.putExtra(SurveyService.SERVICE_METHOD, SurveyService.RELOAD_DASHBOARD_ACTION);
         applicationContext.startService(surveysIntent);
-    }
-
-    /**
-     * This method check the org_unit not is invalid, and is not banned, and later check if the server is valid.
-     * @return return true if all is correct.
-     */
-    public boolean isNetworkAvailable(){
-        ConnectivityManager conMgr = (ConnectivityManager) applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo i = conMgr.getActiveNetworkInfo();
-        if (i == null)
-            return false;
-        if (!i.isConnected())
-            return false;
-        if (!i.isAvailable())
-            return false;
-        return true;
     }
 
     /**

--- a/app/src/main/java/org/eyeseetea/malariacare/receivers/AlarmPushReceiver.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/receivers/AlarmPushReceiver.java
@@ -28,8 +28,10 @@ import android.content.Intent;
 import android.util.Log;
 
 import org.eyeseetea.malariacare.R;
+import org.eyeseetea.malariacare.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.services.PushService;
 import org.eyeseetea.malariacare.services.SurveyService;
+import org.eyeseetea.malariacare.utils.Utils;
 
 /**
  * Created by rhardjono on 20/09/2015.
@@ -76,21 +78,25 @@ public class AlarmPushReceiver extends BroadcastReceiver {
 
     public void setPushAlarm(Context context) {
         Log.d(TAG, "setPushAlarm");
-        long pushPeriod;
-        if(fail) {
-            pushPeriod= Long.parseLong(context.getString(R.string.PUSH_FAILED_PERIOD));
+        if (!Utils.isNetworkAvailable()){
+            cancelPushAlarm(PreferencesState.getInstance().getContext());
         }
-        else{
-            pushPeriod= Long.parseLong(context.getString(R.string.PUSH_PERIOD));
-        }
-        AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        Intent intent = new Intent(context, AlarmPushReceiver.class);
-        //Note FLAG_UPDATE_CURRENT
-        PendingIntent pi = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-        am.setRepeating(AlarmManager.RTC_WAKEUP, System.currentTimeMillis(), pushPeriod * SECONDS, pi);
+        else {
+            long pushPeriod;
+            if(fail) {
+                pushPeriod= Long.parseLong(context.getString(R.string.PUSH_FAILED_PERIOD));
+            } else{
+                pushPeriod= Long.parseLong(context.getString(R.string.PUSH_PERIOD));
+            }
+            AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+            Intent intent = new Intent(context, AlarmPushReceiver.class);
+            //Note FLAG_UPDATE_CURRENT
+            PendingIntent pi = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+            am.setRepeating(AlarmManager.RTC_WAKEUP, System.currentTimeMillis(), pushPeriod * SECONDS, pi);
 
-        //others modes:
-        //am.setInexactRepeating(AlarmManager.RTC_WAKEUP, System.currentTimeMillis(), AlarmManager.INTERVAL_FIFTEEN_MINUTES, pi);
+            //others modes:
+            //am.setInexactRepeating(AlarmManager.RTC_WAKEUP, System.currentTimeMillis(), AlarmManager.INTERVAL_FIFTEEN_MINUTES, pi);
+        }
     }
 
     public void cancelPushAlarm(Context context) {

--- a/app/src/main/java/org/eyeseetea/malariacare/services/SurveyService.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/services/SurveyService.java
@@ -398,6 +398,8 @@ public class SurveyService extends IntentService {
         //Returning result to anyone listening
         Intent resultIntent= new Intent(ALL_COMPLETED_SURVEYS_ACTION);
         LocalBroadcastManager.getInstance(this).sendBroadcast(resultIntent);
+
+        getAllSentCompletedOrConflictSurveys();
     }
 
     /**

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/Utils.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/Utils.java
@@ -19,6 +19,10 @@
 
 package org.eyeseetea.malariacare.utils;
 
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
 import com.raizlabs.android.dbflow.structure.BaseModel;
 
 import org.eyeseetea.malariacare.database.model.CompositeScore;
@@ -110,5 +114,19 @@ public class Utils {
         Locale locale = PreferencesState.getInstance().getContext().getResources().getConfiguration().locale;
         DateFormat dateFormatter = DateFormat.getDateInstance(DateFormat.DEFAULT, locale);
         return dateFormatter.format(date);
+    }
+
+
+    /**
+     * This method check if the Internet conexion is active
+     * @return return true if all is correct.
+     */
+    public static boolean isNetworkAvailable(){
+        ConnectivityManager cm =
+                (ConnectivityManager) PreferencesState.getInstance().getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo netInfo = cm.getActiveNetworkInfo();
+        if(netInfo==null)
+            return false;
+        return netInfo.isConnected();
     }
 }


### PR DESCRIPTION
Closes #885 

@ifoche I reviewed all the process and  I fixed the problem (The sent/complete list should be reloaded when the user mark to completed one survey).


Added:
-New test - Check if a new completed survey is in improve tab.
-I added a new condition in Push test. 
When you push one survey, the event list in dhis db is only incremented by one event.

-I fixed some problems with the push.

When you was pushing a survey, and the  network connection was lost, sometimes the survey was set as conflict.
I resolved this here: [commit](https://github.com/EyeSeeTea/malariapp/commit/a76a7499b1d7a9e92fd4e6fb85164c9f3b57d7d2)


-And i added better  control of the network connection.