### PR TITLE
Added in database wipe the SurveySchedule and OrgUnitProgramRelation

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/database/utils/PopulateDB.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/utils/PopulateDB.java
@@ -15,12 +15,14 @@ import org.eyeseetea.malariacare.database.model.Match;
 import org.eyeseetea.malariacare.database.model.Option;
 import org.eyeseetea.malariacare.database.model.OrgUnit;
 import org.eyeseetea.malariacare.database.model.OrgUnitLevel;
+import org.eyeseetea.malariacare.database.model.OrgUnitProgramRelation;
 import org.eyeseetea.malariacare.database.model.Program;
 import org.eyeseetea.malariacare.database.model.Question;
 import org.eyeseetea.malariacare.database.model.QuestionOption;
 import org.eyeseetea.malariacare.database.model.QuestionRelation;
 import org.eyeseetea.malariacare.database.model.Score;
 import org.eyeseetea.malariacare.database.model.Survey;
+import org.eyeseetea.malariacare.database.model.SurveySchedule;
 import org.eyeseetea.malariacare.database.model.Tab;
 import org.eyeseetea.malariacare.database.model.TabGroup;
 import org.eyeseetea.malariacare.database.model.User;
@@ -204,8 +206,10 @@ public class PopulateDB {
                 Value.class,
                 Score.class,
                 Survey.class,
+                SurveySchedule.class,
                 OrgUnit.class,
                 OrgUnitLevel.class,
+                OrgUnitProgramRelation.class,
                 User.class,
                 QuestionOption.class,
                 Match.class,


### PR DESCRIPTION
@ifoche in dhis sdk the MetaDataController.wipe() method only remove the metadata.

We aren't removing the Event, DataValue, FailedItem and OptionAttributeValue tables.

And i think we forget add the table OptionAttributeValue in the wipe() method of MetaDataController.
I think we need add in our app a method to remove the dhis data before pull, and add OptionAttributeValue in the wipe method in the sdk.