### PR TITLE
Added: show the "parent CompositeScore" questions too.

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/database/utils/feedback/FeedbackBuilder.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/utils/feedback/FeedbackBuilder.java
@@ -66,7 +66,10 @@ public class FeedbackBuilder {
             //Remove parents from list (to avoid showing the parent composite that is there just to push the overall score)
             for (Iterator<CompositeScore> iterator = compositeScoreList.iterator(); iterator.hasNext(); ) {
                 CompositeScore compositeScore = iterator.next();
-                if (!compositeScore.hasParent()) iterator.remove();
+                //Show only if a parent have questions.
+                if(compositeScore.getQuestions().size()<1) {
+                    if (!compositeScore.hasParent()) iterator.remove();
+                }
             }
         }
 


### PR DESCRIPTION
closes #1018 
Checked root CS.
Fixed: If a question have a CS and that CS is the parent CS, the question is shown in the feedback too.