### PR TITLE
Modify sdkPullController: pull of organisationUnit and end the pull p…

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/ProgressActivity.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/ProgressActivity.java
@@ -387,10 +387,10 @@ public class ProgressActivity extends Activity {
         return R.string.dialog_push_success;
     }
 
-    private void annotateFirstPull(boolean value) {
-        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+    private static void annotateFirstPull(boolean value) {
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(PreferencesState.getInstance().getContext());
         SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putBoolean(getString(R.string.pull_metadata), value);
+        editor.putBoolean(PreferencesState.getInstance().getContext().getString(R.string.pull_metadata), value);
         editor.commit();
     }
 
@@ -529,6 +529,9 @@ public class ProgressActivity extends Activity {
     }
 
     public static void postFinish() {
+
+        ProgressActivity.annotateFirstPull(true);
+        finishAndGo(DashboardActivity.class);
         //// FIXME: 28/11/2016 
         //showAndMoveOn();
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/sdk/SdkController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/sdk/SdkController.java
@@ -90,7 +90,12 @@ public abstract class SdkController {
     }
 
     public static void postFinish() {
+        //// FIXME: 11/01/17 I think this user should be get from the SDK user
         User user = User.getLoggedUser();
+        if(user==null) {
+            user = new User();
+            user.save();
+        }
         Session.setUser(user);
         ProgressActivity.postFinish();
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/sdk/SdkPullController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/sdk/SdkPullController.java
@@ -179,7 +179,7 @@ public class SdkPullController extends SdkController {
                 (organisationUnitFlow);
 
         org.hisp.dhis.client.sdk.models.program.Program program = ProgramFlow.MAPPER.mapToModel(programFlow);
-        Observable<List<Event>> eventListObservable = D2.events().pull(
+        Observable<List<Event>> eventListObservable = D2.events().list(
                 organisationUnit,
                 program);
         eventListObservable.

--- a/app/src/main/java/org/eyeseetea/malariacare/sdk/SdkPullController.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/sdk/SdkPullController.java
@@ -169,7 +169,7 @@ public class SdkPullController extends SdkController {
                 .subscribe(new Action1<List<OrganisationUnit>>() {
                     @Override
                     public void call(List<OrganisationUnit> organisationUnits) {
-                        Log.e(TAG, "OrganisationUnit: Done"); 
+                        Log.d(TAG, "OrganisationUnit: Done");
                         asyncDownloads--;
                         if(pullData) {
                             loadDataValues();

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -106,5 +106,6 @@
     <string name="progress_push_preparing_program_stage_sections" translatable="false">"Downloading program stage sections ..."</string>
     <string name="progress_push_preparing_program_stage_dataElements" translatable="false">"Downloading program stage data elements ..."</string>
     <string name="progress_push_preparing_dataElements" translatable="false">"Downloading data elements ..."</string>
+    <string name="progress_push_preparing_organisationUnits" translatable="false">"Downloading organisationUnits ..."</string>
     <string name="progress_push_preparing_events" translatable="false">"Downloading events ..."</string>
     </resources>


### PR DESCRIPTION
I introduce some changes:
Pull of organisationUnits.
Fix postFinish to finish the pull ( if it is correct).
Comment the start of conversion. TODO: uncomment it when works with the conversion.
Added a pullEvent example with only one valid event uid, and ignore the pullEvent error on the observer.
Refactor the showError method.
Remove some not used methods.
