### PR TITLE
Feature new sdk fix event date null on pull

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/ConversionLocalDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/datasources/ConversionLocalDataSource.java
@@ -368,8 +368,10 @@ public class ConversionLocalDataSource {
                         organisationUnit.getLabel(), program.getDisplayName());
                 for (EventExtended event : events) {
                     if (!PullController.PULL_IS_ACTIVE) return;
-                    if (event.getEventDate() == null || event.getEventDate().equals("")) {
-                        break;
+                    if (event.getEventDate() == null
+                            || event.getEventDate().equals("")) {
+                        Log.d(TAG, "Alert, ignoring event without eventdate, event uid:"+event.getUid());
+                        continue;
                     }
                     event.accept(converter);
                 }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/importer/models/EventExtended.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/importer/models/EventExtended.java
@@ -19,10 +19,8 @@
 
 package org.eyeseetea.malariacare.data.database.iomodules.dhis.importer.models;
 
-import com.raizlabs.android.dbflow.sql.language.Method;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
 import com.raizlabs.android.dbflow.sql.language.Select;
-import com.raizlabs.android.dbflow.sql.language.property.Property;
 
 import org.eyeseetea.malariacare.data.database.iomodules.dhis.importer.IConvertFromSDKVisitor;
 import org.eyeseetea.malariacare.data.database.iomodules.dhis.importer.VisitableFromSDK;
@@ -113,7 +111,11 @@ public class EventExtended implements VisitableFromSDK {
      * Returns the survey.eventDate associated with this event (eventDate field)
      */
     public Date getEventDate() {
-        return event.getEventDate().toDate();
+        if (event.getEventDate() != null) {
+            return event.getEventDate().toDate();
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -145,11 +147,10 @@ public class EventExtended implements VisitableFromSDK {
         }
     }
 
-    public static Date parseLongDate(String dateAsString){
+    public static Date parseLongDate(String dateAsString) {
         try {
             return parseDate(dateAsString, DHIS2_GMT_DATE_FORMAT);
         } catch (ParseException ex) {
-            ex.printStackTrace();
             return parseShortDate(dateAsString);
         }
     }

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/importer/models/EventExtended.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/iomodules/dhis/importer/models/EventExtended.java
@@ -111,31 +111,18 @@ public class EventExtended implements VisitableFromSDK {
      * Returns the survey.eventDate associated with this event (eventDate field)
      */
     public Date getEventDate() {
-        if (event.getEventDate() != null) {
-            return event.getEventDate().toDate();
-        } else {
-            return null;
-        }
+        return (event.getEventDate() != null) ? event.getEventDate().toDate() : null;
     }
 
     /**
      * Returns the survey.eventDate associated with this event (dueDate field)
      */
     public Date getDueDate() {
-        if (event == null) {
-            return null;
-        }
-
-        return event.getDueDate().toDate();
+        return (event != null) ? event.getDueDate().toDate() : null;
     }
 
     public static Date parseDate(String dateAsString, String format) throws ParseException {
-        if (dateAsString == null) {
-            return null;
-        }
-
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(format);
-        return simpleDateFormat.parse(dateAsString);
+        return (dateAsString != null) ? new SimpleDateFormat(format).parse(dateAsString) : null;
     }
 
     public static Date parseShortDate(String dateAsString) {
@@ -167,11 +154,7 @@ public class EventExtended implements VisitableFromSDK {
      * Turns a given date into a parseable String according to sdk date format
      */
     public static String format(Date date, String format) {
-        if (date == null) {
-            return null;
-        }
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(format);
-        return simpleDateFormat.format(date);
+        return (date != null) ? new SimpleDateFormat(format).format(date) : null;
     }
 
 

--- a/app/src/main/java/org/eyeseetea/malariacare/data/database/model/CompositeScore.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/database/model/CompositeScore.java
@@ -218,11 +218,6 @@ public class CompositeScore extends BaseModel implements VisitableToSDK {
                 .orderBy(CompositeScore_Table.order_pos, true)
                 .queryList();
 
-        // remove duplicates
-        Set<CompositeScore> uniqueCompositeScoresByProgram = new HashSet<>();
-        uniqueCompositeScoresByProgram.addAll(compositeScoresByProgram);
-        compositeScoresByProgram.clear();
-        compositeScoresByProgram.addAll(uniqueCompositeScoresByProgram);
 
         //Find parent scores from 'leaves'
         Set<CompositeScore> parentCompositeScores = new HashSet<>();
@@ -231,6 +226,11 @@ public class CompositeScore extends BaseModel implements VisitableToSDK {
         }
         compositeScoresByProgram.addAll(parentCompositeScores);
 
+        // remove duplicates
+        Set<CompositeScore> uniqueCompositeScoresByProgram = new HashSet<>();
+        uniqueCompositeScoresByProgram.addAll(compositeScoresByProgram);
+        compositeScoresByProgram.clear();
+        compositeScoresByProgram.addAll(uniqueCompositeScoresByProgram);
 
         Collections.sort(compositeScoresByProgram, new Comparator() {
 
@@ -243,7 +243,6 @@ public class CompositeScore extends BaseModel implements VisitableToSDK {
                 return new Integer(cs1.getOrder_pos().compareTo(new Integer(cs2.getOrder_pos())));
             }
         });
-
 
 
         //return all scores

--- a/app/src/main/java/org/eyeseetea/malariacare/data/remote/PushDhisSDKDataSource.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/data/remote/PushDhisSDKDataSource.java
@@ -60,7 +60,9 @@ public class PushDhisSDKDataSource {
         final Set<String> eventUids = new HashSet<>();
 
         for (EventFlow eventFlow : SdkQueries.getEvents()) {
-            eventUids.add(eventFlow.getUId());
+            if(eventFlow.getEventDate()!=null) {
+                eventUids.add(eventFlow.getUId());
+            }
         }
         Observable<Map<String, ImportSummary>> eventObserver =
                 D2.events().push(eventUids);


### PR DESCRIPTION
Closes #1289 
The error was generated by blank surveys.
The blank surveys was pushed when a survey have a repeated dataValue. I solved it for a repeat CS dataValue. In this case the repeated value was the CS 1.2 of ZW HIV. 
This CS was saved two times because was listed two times, the first time was added  because is a CS of a question, and the second was added because is a parent of another CS. 
This was solved  removing the duplicate CS from the CS list.