### PR TITLE
Fix locale date formats

### DIFF
--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -40,6 +40,7 @@ import org.eyeseetea.malariacare.database.utils.LocationMemory;
 import org.eyeseetea.malariacare.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.database.utils.Session;
 import org.eyeseetea.malariacare.database.utils.planning.SurveyPlanner;
+import org.eyeseetea.malariacare.domain.entity.DateQuestion;
 import org.eyeseetea.malariacare.layout.score.ScoreRegister;
 import org.eyeseetea.malariacare.network.PullClient;
 import org.eyeseetea.malariacare.utils.Constants;
@@ -302,7 +303,10 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
         dataValue.setEvent(currentEvent.getEvent());
         dataValue.setProvidedElsewhere(false);
         dataValue.setStoredBy(getSafeUsername());
-        if(value.getOption()!=null){
+        if(value.getQuestion() != null && value.getQuestion().getOutput() == Constants.DATE){
+            Date valueDate= DateQuestion.formatDateOutput(value.getValue());
+            dataValue.setValue(DateQuestion.formatDateToValue(valueDate));
+        }else if(value.getOption()!=null){
             dataValue.setValue(value.getOption().getCode());
         }else{
             dataValue.setValue(value.getValue());

--- a/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/database/iomodules/dhis/exporter/ConvertToSDKVisitor.java
@@ -40,7 +40,7 @@ import org.eyeseetea.malariacare.database.utils.LocationMemory;
 import org.eyeseetea.malariacare.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.database.utils.Session;
 import org.eyeseetea.malariacare.database.utils.planning.SurveyPlanner;
-import org.eyeseetea.malariacare.domain.entity.DateQuestion;
+import org.eyeseetea.malariacare.utils.DateQuestionFormatter;
 import org.eyeseetea.malariacare.layout.score.ScoreRegister;
 import org.eyeseetea.malariacare.network.PullClient;
 import org.eyeseetea.malariacare.utils.Constants;
@@ -304,8 +304,8 @@ public class ConvertToSDKVisitor implements IConvertToSDKVisitor {
         dataValue.setProvidedElsewhere(false);
         dataValue.setStoredBy(getSafeUsername());
         if(value.getQuestion() != null && value.getQuestion().getOutput() == Constants.DATE){
-            Date valueDate= DateQuestion.formatDateOutput(value.getValue());
-            dataValue.setValue(DateQuestion.formatDateToValue(valueDate));
+            Date valueDate= DateQuestionFormatter.formatDateOutput(value.getValue());
+            dataValue.setValue(DateQuestionFormatter.formatDateToValue(valueDate));
         }else if(value.getOption()!=null){
             dataValue.setValue(value.getOption().getCode());
         }else{

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/entity/DateQuestion.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/entity/DateQuestion.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2017.
+ *
+ * This file is part of QA App.
+ *
+ *  Health Network QIS App is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Health Network QIS App is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eyeseetea.malariacare.domain.entity;
+
+import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.EventExtended;
+import org.eyeseetea.malariacare.database.utils.PreferencesState;
+import org.eyeseetea.malariacare.domain.exception.DateFormatException;
+
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Locale;
+
+public class DateQuestion {
+
+    //Format a date to value using server format
+    public static String formatDateToValue(Date date) {
+        if(date==null){
+            return "-";
+        }
+        try {
+            return EventExtended.format(date, EventExtended.AMERICAN_DATE_FORMAT);
+        }catch (Exception e){
+            e.printStackTrace();
+            return "-";
+        }
+    }
+
+    //Format a date to view using locale format
+    public static String formatDateToView(Date date) {
+        if(date==null){
+            return "-";
+        }
+        try {
+            return formatLocaleDateToString(date);
+        }catch (DateFormatException ex){
+            ex.printStackTrace();
+            return "-";
+        }
+    }
+
+    //Parse the saved date
+    public static Date formatDateOutput(String value) {
+        Date date;
+        try {
+            date = formatFromNewOutput(value);
+        }catch (DateFormatException ex){
+            ex.printStackTrace();
+            try {
+                date = formatFromOldOutput(value);
+            } catch (DateFormatException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }
+        return date;
+    }
+
+    //Parse the saved date from server format
+    public static Date formatFromNewOutput(String value) throws DateFormatException{
+        try{
+            return EventExtended.parseDate(value, EventExtended.AMERICAN_DATE_FORMAT);
+        }catch(ParseException ex){
+            ex.printStackTrace();
+            throw new DateFormatException();
+        }
+    }
+
+    //Parse the saved date from locale formatt
+    public static Date formatFromOldOutput(String value) throws DateFormatException{
+        try{
+            return formatLocaleDateStringToDate(value);
+        }catch(ParseException ex){
+            ex.printStackTrace();
+            throw new DateFormatException();
+        }
+    }
+
+
+    //Returns a string formatted date with the locale format
+    public static String formatLocaleDateToString(Date date) throws DateFormatException {
+        String dateAsLocaleString;
+        try {
+            Locale locale =
+                    PreferencesState.getInstance().getContext().getResources().getConfiguration().locale;
+
+            java.text.DateFormat dateFormatter = java.text.DateFormat.getDateInstance(
+                    java.text.DateFormat.DEFAULT, locale);
+            dateAsLocaleString = dateFormatter.format(date);
+        }catch (Exception e){
+            e.printStackTrace();
+            throw  new DateFormatException();
+        }
+        return dateAsLocaleString;
+    }
+
+    //Returns a date parse from a string locale formatted date
+    public static Date formatLocaleDateStringToDate(String value) throws ParseException {
+        Locale locale = PreferencesState.getInstance().getContext().getResources().getConfiguration().locale;
+        java.text.DateFormat dateFormatter = java.text.DateFormat.getDateInstance(
+                java.text.DateFormat.DEFAULT, locale);
+        return dateFormatter.parse(value);
+    }
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/domain/exception/DateFormatException.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/domain/exception/DateFormatException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017.
+ *
+ * This file is part of QA App.
+ *
+ *  Health Network QIS App is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Health Network QIS App is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.eyeseetea.malariacare.domain.exception;
+
+public class DateFormatException extends Exception {
+    public DateFormatException(){ super("Date format invalid");}
+}

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/AutoTabAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/AutoTabAdapter.java
@@ -49,7 +49,7 @@ import org.eyeseetea.malariacare.database.model.Tab;
 import org.eyeseetea.malariacare.database.model.Value;
 import org.eyeseetea.malariacare.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.database.utils.ReadWriteDB;
-import org.eyeseetea.malariacare.domain.entity.DateQuestion;
+import org.eyeseetea.malariacare.utils.DateQuestionFormatter;
 import org.eyeseetea.malariacare.layout.adapters.general.OptionArrayAdapter;
 import org.eyeseetea.malariacare.layout.score.ScoreRegister;
 import org.eyeseetea.malariacare.layout.utils.AutoTabInVisibilityState;
@@ -518,9 +518,9 @@ public class AutoTabAdapter extends ATabAdapter {
         switch (question.getOutput()) {
             case Constants.DATE:
                 String valueString=ReadWriteDB.readValueQuestion(question, module);
-                Date valueDate= DateQuestion.formatDateOutput(valueString);
+                Date valueDate= DateQuestionFormatter.formatDateOutput(valueString);
                 if(valueDate!=null) {
-                    viewHolder.setText(DateQuestion.formatDateToView(valueDate));
+                    viewHolder.setText(DateQuestionFormatter.formatDateToView(valueDate));
                 }
                 break;
             case Constants.SHORT_TEXT:
@@ -757,9 +757,9 @@ public class AutoTabAdapter extends ATabAdapter {
                     Date newScheduledDate = newCalendar.getTime();
                     if(!isCleared) {
                         ((CustomButton) v).setText(
-                                DateQuestion.formatDateToView(newCalendar.getTime()));
+                                DateQuestionFormatter.formatDateToView(newCalendar.getTime()));
                         ReadWriteDB.saveValuesText(question,
-                                DateQuestion.formatDateToValue(newCalendar.getTime()), module);
+                                DateQuestionFormatter.formatDateToValue(newCalendar.getTime()), module);
                     }
                     isCleared =false;
                 }

--- a/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/AutoTabAdapter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/layout/adapters/survey/AutoTabAdapter.java
@@ -29,8 +29,6 @@ import android.os.Build;
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextWatcher;
-import android.util.Log;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
@@ -43,10 +41,7 @@ import android.widget.RadioGroup;
 import android.widget.Spinner;
 import android.widget.Switch;
 
-import com.raizlabs.android.dbflow.structure.BaseModel;
-
 import org.eyeseetea.malariacare.R;
-import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.EventExtended;
 import org.eyeseetea.malariacare.database.model.Header;
 import org.eyeseetea.malariacare.database.model.Option;
 import org.eyeseetea.malariacare.database.model.Question;
@@ -54,6 +49,7 @@ import org.eyeseetea.malariacare.database.model.Tab;
 import org.eyeseetea.malariacare.database.model.Value;
 import org.eyeseetea.malariacare.database.utils.PreferencesState;
 import org.eyeseetea.malariacare.database.utils.ReadWriteDB;
+import org.eyeseetea.malariacare.domain.entity.DateQuestion;
 import org.eyeseetea.malariacare.layout.adapters.general.OptionArrayAdapter;
 import org.eyeseetea.malariacare.layout.score.ScoreRegister;
 import org.eyeseetea.malariacare.layout.utils.AutoTabInVisibilityState;
@@ -62,7 +58,6 @@ import org.eyeseetea.malariacare.layout.utils.AutoTabSelectedItem;
 import org.eyeseetea.malariacare.layout.utils.AutoTabViewHolder;
 import org.eyeseetea.malariacare.layout.utils.LayoutUtils;
 import org.eyeseetea.malariacare.layout.utils.QuestionRow;
-import org.eyeseetea.malariacare.utils.AUtils;
 import org.eyeseetea.malariacare.utils.Constants;
 import org.eyeseetea.malariacare.views.CustomButton;
 import org.eyeseetea.malariacare.views.CustomEditText;
@@ -73,7 +68,6 @@ import org.eyeseetea.malariacare.views.filters.MinMaxInputFilter;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.LinkedHashMap;
 import java.util.List;
 
 
@@ -524,9 +518,9 @@ public class AutoTabAdapter extends ATabAdapter {
         switch (question.getOutput()) {
             case Constants.DATE:
                 String valueString=ReadWriteDB.readValueQuestion(question, module);
-                Date valueDate= EventExtended.parseShortDate(valueString);
+                Date valueDate= DateQuestion.formatDateOutput(valueString);
                 if(valueDate!=null) {
-                    viewHolder.setText(ReadWriteDB.readValueQuestion(question, module));
+                    viewHolder.setText(DateQuestion.formatDateToView(valueDate));
                 }
                 break;
             case Constants.SHORT_TEXT:
@@ -762,8 +756,10 @@ public class AutoTabAdapter extends ATabAdapter {
                     newCalendar.set(year, monthOfYear, dayOfMonth);
                     Date newScheduledDate = newCalendar.getTime();
                     if(!isCleared) {
-                        ((CustomButton) v).setText( AUtils.formatDate(newCalendar.getTime()));
-                        ReadWriteDB.saveValuesText(question, AUtils.formatDate(newCalendar.getTime()), module);
+                        ((CustomButton) v).setText(
+                                DateQuestion.formatDateToView(newCalendar.getTime()));
+                        ReadWriteDB.saveValuesText(question,
+                                DateQuestion.formatDateToValue(newCalendar.getTime()), module);
                     }
                     isCleared =false;
                 }

--- a/app/src/main/java/org/eyeseetea/malariacare/utils/DateQuestionFormatter.java
+++ b/app/src/main/java/org/eyeseetea/malariacare/utils/DateQuestionFormatter.java
@@ -17,7 +17,7 @@
  *  along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.eyeseetea.malariacare.domain.entity;
+package org.eyeseetea.malariacare.utils;
 
 import org.eyeseetea.malariacare.database.iomodules.dhis.importer.models.EventExtended;
 import org.eyeseetea.malariacare.database.utils.PreferencesState;
@@ -27,7 +27,7 @@ import java.text.ParseException;
 import java.util.Date;
 import java.util.Locale;
 
-public class DateQuestion {
+public class DateQuestionFormatter {
 
     //Format a date to value using server format
     public static String formatDateToValue(Date date) {


### PR DESCRIPTION
Closes #1385
The date tipe wasn't invalid, but we was saving and pushing the default locale format and this is incompatible with the server in some cases.

The value is now pushed and stored with the server format, but is displayed with the locale format in the views. 